### PR TITLE
Updated versions of java and spring, config service covered with test…

### DIFF
--- a/config-service/Dockerfile
+++ b/config-service/Dockerfile
@@ -1,5 +1,5 @@
 # ── Stage 1: Build ──────────────────────────────────────────────────────────
-FROM maven:3.9-eclipse-temurin-17 AS build
+FROM maven:3.9-eclipse-temurin-25 AS build
 
 WORKDIR /app
 
@@ -12,7 +12,9 @@ COPY src ./src
 RUN mvn clean package -DskipTests -B
 
 # ── Stage 2: Runtime ─────────────────────────────────────────────────────────
-FROM eclipse-temurin:17-jre
+FROM eclipse-temurin:25-jre
+
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 

--- a/config-service/pom.xml
+++ b/config-service/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.0</version>
+        <version>4.0.5</version>
         <relativePath/>
     </parent>
 
@@ -18,8 +18,8 @@
     <description>CookMate Config Server</description>
 
     <properties>
-        <java.version>17</java.version>
-        <spring-cloud.version>2024.0.0</spring-cloud.version>
+        <java.version>25</java.version>
+        <spring-cloud.version>2025.1.1</spring-cloud.version>
     </properties>
 
     <dependencies>
@@ -33,7 +33,29 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webclient</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webmvc-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-restclient-test</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/config-service/src/test/java/com/cookmate/config/ConfigServiceIntegrationTest.java
+++ b/config-service/src/test/java/com/cookmate/config/ConfigServiceIntegrationTest.java
@@ -1,0 +1,65 @@
+package com.cookmate.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.client.RestTestClient;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@AutoConfigureRestTestClient
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {
+        "spring.cloud.config.server.native.search-locations=file:../config-repo"
+})
+class ConfigServiceIntegrationTest {
+
+    record ConfigResponse(String name, List<PropertySource> propertySources) {}
+    record PropertySource(String name, Map<String, Object> source) {}
+
+    @Autowired
+    private RestTestClient client;
+
+    @Test
+    void shouldLoadApplicationYaml() {
+        client.get()
+                .uri("/application/default")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(ConfigResponse.class).value(response -> {
+                    assertThat(response.propertySources())
+                            .isNotEmpty();
+
+                    var globalSource = response.propertySources().stream()
+                            .filter(ps -> ps.name().contains("application.yml"))
+                            .findFirst()
+                            .map(PropertySource::source)
+                            .orElseThrow();
+
+                    assertThat(globalSource.get("management.endpoints.web.exposure.include")).isEqualTo("health,info,metrics");
+                });
+    }
+
+    @Test
+    void shouldLoadMainServiceYaml() {
+        client.get()
+                .uri("/main-service/default")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(ConfigResponse.class).value(response -> {
+                    assertThat(response.name()).isEqualTo("main-service");
+                    assertThat(response.propertySources()).isNotEmpty();
+
+                    var serviceSource = response.propertySources().stream()
+                            .filter(ps -> ps.name().contains("main-service.yml"))
+                            .findFirst()
+                            .map(PropertySource::source)
+                            .orElseThrow(() -> new AssertionError("Nie znaleziono pliku main-service.yml w odpowiedzi"));
+
+                    assertThat(serviceSource.get("server.port")).isEqualTo(8081);
+                });
+    }
+}

--- a/discovery-service/Dockerfile
+++ b/discovery-service/Dockerfile
@@ -1,5 +1,5 @@
 # ── Stage 1: Build ──────────────────────────────────────────────────────────
-FROM maven:3.9-eclipse-temurin-17 AS build
+FROM maven:3.9-eclipse-temurin-25 AS build
 
 WORKDIR /app
 
@@ -12,7 +12,9 @@ COPY src ./src
 RUN mvn clean package -DskipTests -B
 
 # ── Stage 2: Runtime ─────────────────────────────────────────────────────────
-FROM eclipse-temurin:17-jre
+FROM eclipse-temurin:25-jre
+
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 

--- a/discovery-service/pom.xml
+++ b/discovery-service/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.0</version>
+        <version>4.0.5</version>
         <relativePath/>
     </parent>
 
@@ -18,8 +18,8 @@
     <description>CookMate Discovery Server (Eureka)</description>
 
     <properties>
-        <java.version>17</java.version>
-        <spring-cloud.version>2024.0.0</spring-cloud.version>
+        <java.version>25</java.version>
+        <spring-cloud.version>2025.1.1</spring-cloud.version>
     </properties>
 
     <dependencies>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 networks:
   cookmate-net:
     driver: bridge
@@ -13,7 +11,7 @@ services:
   # PostgreSQL Database
   # ─────────────────────────────────────────────
   postgres:
-    image: postgres:16-alpine
+    image: postgres:18-alpine
     container_name: cookmate-postgres
     restart: unless-stopped
     environment:

--- a/main-service/Dockerfile
+++ b/main-service/Dockerfile
@@ -1,5 +1,5 @@
 # ── Stage 1: Build ──────────────────────────────────────────────────────────
-FROM maven:3.9-eclipse-temurin-17 AS build
+FROM maven:3.9-eclipse-temurin-25 AS build
 
 WORKDIR /app
 
@@ -12,7 +12,9 @@ COPY src ./src
 RUN mvn clean package -DskipTests -B
 
 # ── Stage 2: Runtime ─────────────────────────────────────────────────────────
-FROM eclipse-temurin:17-jre
+FROM eclipse-temurin:25-jre
+
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 

--- a/main-service/pom.xml
+++ b/main-service/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.0</version>
+        <version>4.0.5</version>
         <relativePath/>
     </parent>
 
@@ -18,8 +18,8 @@
     <description>CookMate Main Service - Recipe Management</description>
 
     <properties>
-        <java.version>17</java.version>
-        <spring-cloud.version>2024.0.0</spring-cloud.version>
+        <java.version>25</java.version>
+        <spring-cloud.version>2025.1.1</spring-cloud.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -19,9 +19,9 @@
     </modules>
 
     <properties>
-        <java.version>17</java.version>
-        <spring-boot.version>3.4.0</spring-boot.version>
-        <spring-cloud.version>2024.0.0</spring-cloud.version>
+        <java.version>25</java.version>
+        <spring-boot.version>4.0.5</spring-boot.version>
+        <spring-cloud.version>2025.1.1</spring-cloud.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/simulator-service/Dockerfile
+++ b/simulator-service/Dockerfile
@@ -1,5 +1,5 @@
 # ── Stage 1: Build ──────────────────────────────────────────────────────────
-FROM maven:3.9-eclipse-temurin-17 AS build
+FROM maven:3.9-eclipse-temurin-25 AS build
 
 WORKDIR /app
 
@@ -12,7 +12,9 @@ COPY src ./src
 RUN mvn clean package -DskipTests -B
 
 # ── Stage 2: Runtime ─────────────────────────────────────────────────────────
-FROM eclipse-temurin:17-jre
+FROM eclipse-temurin:25-jre
+
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 

--- a/simulator-service/pom.xml
+++ b/simulator-service/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.0</version>
+        <version>4.0.5</version>
         <relativePath/>
     </parent>
 
@@ -18,8 +18,8 @@
     <description>CookMate Simulator Service - Recipe Meal Planner</description>
 
     <properties>
-        <java.version>17</java.version>
-        <spring-cloud.version>2024.0.0</spring-cloud.version>
+        <java.version>25</java.version>
+        <spring-cloud.version>2025.1.1</spring-cloud.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
This pull request upgrades the entire project stack to use Java 25 and Spring Boot 4, updates Docker images accordingly, and adds integration tests for the config service. The changes ensure compatibility with the latest Java and Spring Cloud versions, update dependencies, and improve test coverage for configuration loading.

**Platform and Dependency Upgrades:**

* Migrated all services (`config-service`, `discovery-service`, `main-service`, `simulator-service`) to Java 25 and Spring Boot 4.0.5, updating parent POMs, `java.version`, and `spring-cloud.version` properties in all relevant `pom.xml` files.

* Updated Dockerfiles for all services to use Maven and JRE images based on Eclipse Temurin 25 instead of 17, and installed `curl` in runtime images for debugging or health checks.

**Dependency and Feature Enhancements:**

* Added new dependencies to `config-service` for web, webmvc, webclient, and related test starters to support new features and improve testability.

**Testing Improvements:**

* Introduced `ConfigServiceIntegrationTest` to verify that the config server correctly loads configuration from YAML files for both the application and main service, increasing confidence in configuration management.

**Infrastructure Updates:**

* Updated the PostgreSQL image in `docker-compose.yml` from version 16-alpine to 18-alpine to ensure compatibility with the latest features and security updates.

**Other:**

* Removed the explicit version declaration from the top of `docker-compose.yml` for simplification.