### PR TITLE
122 11 simulator service implementacja simulationservice

### DIFF
--- a/config-repo/simulator-service.yml
+++ b/config-repo/simulator-service.yml
@@ -2,6 +2,21 @@
 server:
   port: 8082
 
+spring:
+  datasource:
+    url: jdbc:postgresql://${DB_HOST:localhost}:5432/${DB_NAME:cookmate}
+    username: ${DB_USER:cookmate}
+    password: ${DB_PASS:cookmate}
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        format_sql: true
+
 simulator-service:
   main-service-url: http://main-service:8081
   greeting: "Welcome to CookMate Simulator Service"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,7 +118,7 @@ services:
 
   # ─────────────────────────────────────────────
   # Simulator Service (port 8082)
-  # Startup order: 3rd (after discovery)
+  # Startup order: 3rd (after discovery + postgres)
   # ─────────────────────────────────────────────
   simulator-service:
     build:
@@ -131,7 +131,13 @@ services:
     environment:
       CONFIG_SERVER_URL: http://config-service:8888
       EUREKA_SERVER_URL: http://discovery-service:8761/eureka/
+      DB_HOST: postgres
+      DB_NAME: cookmate
+      DB_USER: cookmate
+      DB_PASS: cookmate
     depends_on:
+      postgres:
+        condition: service_healthy
       discovery-service:
         condition: service_healthy
     networks:

--- a/simulator-service/PERSISTENCE.md
+++ b/simulator-service/PERSISTENCE.md
@@ -1,152 +1,56 @@
-# Persistence - Przechowywanie Stanu i Caching
+# Persistence - Przechowywanie Stanu Symulacji
 
-## Strategia Przechowywania Stanu
+## Cel
 
-### Charakterystyka Simulator Service
+Simulator Service przechowuje stan sesji symulacji i historię kroków w PostgreSQL, aby umożliwić:
+- wznowienie sesji po odświeżeniu (F5) lub reconnect,
+- śledzenie postępu krok po kroku,
+- odczyt historii wykonanych i pominiętych kroków.
 
-Simulator Service jest **stateless** - nie przechowuje stanu pomiędzy żądaniami. Każde żądanie jest niezależne i oparte na aktualnym stanie main-service.
+## Model Danych
 
-```
-┌──────────────┐
-│  Request 1   │──→ Fetch recipes from main-service → Generate plan
-└──────────────┘
+### `simulation_sessions`
 
-┌──────────────┐
-│  Request 2   │──→ Fetch recipes from main-service → Generate plan (different)
-└──────────────┘
+Przechowuje metadane sesji:
+- `id` (UUID jako String, klucz główny),
+- `status` (`RUNNING`, `PAUSED`, `COMPLETED`, `CANCELLED`),
+- `current_step`, `total_steps`, `total_recipes`,
+- `message` (np. brak dostępnych przepisów),
+- `created_at`, `updated_at`, `completed_at`.
 
-(Brak współdzielonego stanu między requestami)
-```
+### `simulation_steps`
 
-## Caching
+Przechowuje historię kroków sesji:
+- `id` (auto-generated),
+- `session_id`,
+- `step_number`,
+- `recipe_id`, `recipe_name`, `preparation_time`,
+- `status` (`PENDING`, `EXECUTED`, `SKIPPED`),
+- `executed_at`, `created_at`.
 
-### Brak Cache'u na Poziomie Hosta
+## Repozytoria
 
-Simulator Service **nie implementuje cache'u** lokalnego:
-- Każdy request pobiera świeżą listę przepisów
-- Gwarantuje zawsze aktualne plany posiłków
-- Brak ryzyka stale'ego cache'u
+- `SimulationSessionRepository`
+- `SimulationStepRepository`
 
-### Cache'owanie na Poziomie Sieci (Opcjonalne)
+Repozytoria umożliwiają:
+- odczyt i aktualizację stanu sesji,
+- pobieranie historii kroków po `session_id`,
+- wyznaczanie kolejnego kroku `PENDING` do wykonania.
 
-Można skonfigurować cache'owanie HTTP w API Gateway:
+## Recovery po Disconnect/F5
 
-```yaml
-# Przykład cache-control headers
-Cache-Control: max-age=60, public
-```
+Klient korzysta z trwałego `sessionId`:
+1. start sesji zwraca `sessionId`,
+2. po reconnect klient wywołuje status/historię dla tego samego `sessionId`,
+3. stan (`PAUSED`/`RUNNING`/`COMPLETED`) i wykonane kroki są odtwarzane z bazy.
 
-## Dane Tymczasowe
+## Przejścia Stanu
 
-### Memory Usage
+- `start` -> `RUNNING` (lub `COMPLETED`, gdy brak przepisów),
+- `executeStep` -> aktualizacja kroku `PENDING` na `EXECUTED`,
+- `pause`/`resume` -> zmiana `RUNNING <-> PAUSED`,
+- `complete` -> `COMPLETED`, pozostałe kroki `PENDING` są oznaczane jako `SKIPPED`,
+- `cancel` -> `CANCELLED`, pozostałe kroki `PENDING` są oznaczane jako `SKIPPED`.
 
-Każde żądanie wykorzystuje:
-- ~100KB dla listy przepisów (avg)
-- ~50KB dla struktury planu posiłków
-- **Total: ~150KB per request**
-
-Virtual Threads pozwalają na efektywne zarządzanie pamięcią dzięki lekkiemu footprintowi.
-
-### Garbage Collection
-
-- GC odbywa się automatycznie po zaplanowaniu żądania
-- Typ: ZGC (z25) lub G1GC (domyślny dla Java 25)
-- Stop-the-world: < 1ms (przeciętnie)
-
-## Baza Danych
-
-### Brak Bazy Danych w Simulator Service
-
-Simulator Service **nie ma własnej bazy danych**:
-- Wszystkie dane pochodzą z main-service
-- Nie przechowuje recepty, użytkowników, ani historii planów
-- Czysto **query-only** service
-
-Architektura:
-
-```
-┌──────────────────────────┐
-│ Simulator Service        │
-│  (Stateless, no DB)      │
-└────────────┬─────────────┘
-             │
-             ▼ (OpenFeign)
-┌──────────────────────────┐
-│ Main Service             │
-│ (PostgreSQL, contains    │
-│  all recipes and data)   │
-└──────────────────────────┘
-```
-
-## Skalowanie Horyzontalnego
-
-Simulator Service można skalować horyzontalnie bez problemów:
-
-```
-┌────────────────┐
-│ Load Balancer  │
-└────────┬───────┘
-         │
-         ├──→ Simulator Instance 1 (:8082)
-         ├──→ Simulator Instance 2 (:8082)
-         ├──→ Simulator Instance 3 (:8082)
-         └──→ Simulator Instance N (:8082)
-                    ↓
-              Main Service (single)
-```
-
-Każda instancja:
-- Jest całkowicie stateless
-- Może być uruchamiana/zatrzymywana bez wpływu na inne
-- Komunikuje się z tym samym main-service
-- Automatycznie rejestruje się w Eureka
-
-## Życiorys Żądania
-
-### Żądanie: GET /api/simulator/meal-plan?days=5
-
-```
-1. [T=0ms]    Virtual Thread zostaje stworzony
-2. [T=10ms]   SimulatorController#generateMealPlan() się uruchamia
-3. [T=20ms]   MainServiceClient.getAllRecipes() - HTTP call via OpenFeign
-4. [T=150ms]  Odpowiedź z main-service (42 recepty, ~100KB)
-5. [T=160ms]  Random selection algo (5 iteracji)
-6. [T=170ms]  Serializacja do JSON (~2KB)
-7. [T=180ms]  Response wysyłana do klienta
-8. [T=185ms]  Virtual Thread wznawia pool
-9. [T=200ms]  Garbage Collection (automatycznie)
-```
-
-**Total Latency**: ~185ms (network dominant)
-**Memory Retained**: 0B (wszystko zwolnione)
-
-## Event Sourcing (Opcjonalne)
-
-Dla przyszłych wymagań audit/analytics:
-
-```
-Opcjonalna architektura:
-- Każdy plan posiłków mógłby być logowany do event stream'u
-- Przechowywanie: Message Queue (RabbitMQ) lub Event Log (PostgreSQL)
-- Cel: Analiza popularności przepisów, trendów itp.
-
-Nie jest zaimplementowane w bieżącej wersji.
-```
-
-## Podsumowanie
-
-| Aspekt | Implementacja |
-|--------|---------------|
-| **Stan Aplikacji** | Stateless |
-| **Cache Lokalny** | Brak |
-| **Baza Danych** | Nie posiada |
-| **Pamięć per Request** | ~150KB |
-| **Skalowanie** | Horyzontal (stateless) |
-| **Durability** | N/A (nie przechowuje) |
-| **GC Strategy** | Automatyczne (Virtual Thread friendly) |
-
-Simulator Service jest zaprojektowany dla:
-- ✅ Wysokiej dostępności
-- ✅ Skalowalności horyzontalnej
-- ✅ Niskiego latency
-- ✅ Minimalnego zużycia zasobów
+Nieprawidłowe przejścia zwracają błąd `409 CONFLICT`.

--- a/simulator-service/README.md
+++ b/simulator-service/README.md
@@ -40,6 +40,14 @@ Mikrousługa odpowiedzialna za generowanie planów posiłków na podstawie przep
 | `/api/simulator/recipes/{id}` | GET | `id` (Long) | Pobiera szczegóły konkretnego przepisu |
 | `/api/simulator/meal-plan` | GET | `days` (int, default=3) | Generuje losowy plan posiłków na X dni |
 | `/api/simulator/health-check` | GET | - | Sprawdza dostępność main-service i zwraca status |
+| `/api/simulator/sessions/start` | POST | `days` (int, optional) | Tworzy nową sesję symulacji i zapisuje kroki w bazie |
+| `/api/simulator/sessions/{sessionId}/status` | GET | `sessionId` | Zwraca status sesji (recovery po F5) |
+| `/api/simulator/sessions/{sessionId}/steps/execute` | POST | `sessionId` | Wykonuje kolejny krok symulacji |
+| `/api/simulator/sessions/{sessionId}/pause` | POST | `sessionId` | Pauzuje aktywną sesję |
+| `/api/simulator/sessions/{sessionId}/resume` | POST | `sessionId` | Wznawia zapauzowaną sesję |
+| `/api/simulator/sessions/{sessionId}/complete` | POST | `sessionId` | Kończy sesję symulacji |
+| `/api/simulator/sessions/{sessionId}/cancel` | POST | `sessionId` | Anuluje sesję symulacji |
+| `/api/simulator/sessions/{sessionId}/history` | GET | `sessionId` | Zwraca historię kroków sesji |
 | `/actuator/health` | GET | - | Health check serwisu |
 
 ### Przykładowe Odpowiedzi
@@ -88,6 +96,9 @@ spring:
   threads:
     virtual:
       enabled: true        # Włączenie Virtual Threads (Java 25)
+  datasource:
+    url: jdbc:postgresql://${DB_HOST:localhost}:5432/${DB_NAME:cookmate}
+    username: ${DB_USER:cookmate}
 
 server:
   port: 8082
@@ -139,6 +150,14 @@ Simulator Service komunikuje się z Main Service za pośrednictwem OpenFeign:
 - **Client**: `MainServiceClient` (src/main/java/com/cookmate/simulator/client/)
 - **Base URL**: Pobierana z Eureka Registry
 - **Endpoints**: `/api/recipes`, `/api/recipes/{id}`
+
+## Persistencja Sesji
+
+Simulator Service zapisuje sesje i kroki do PostgreSQL:
+- `simulation_sessions` - status i postęp sesji,
+- `simulation_steps` - historia kroków (`PENDING`, `EXECUTED`, `SKIPPED`).
+
+Szczegóły: **[PERSISTENCE.md](./PERSISTENCE.md)**.
 
 ## Obsługa Błędów
 

--- a/simulator-service/README.md
+++ b/simulator-service/README.md
@@ -99,6 +99,15 @@ spring:
   datasource:
     url: jdbc:postgresql://${DB_HOST:localhost}:5432/${DB_NAME:cookmate}
     username: ${DB_USER:cookmate}
+    password: ${DB_PASSWORD:cookmate}
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
 
 server:
   port: 8082

--- a/simulator-service/pom.xml
+++ b/simulator-service/pom.xml
@@ -29,6 +29,19 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
 
+        <!-- Data JPA -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+
+        <!-- PostgreSQL Driver -->
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
         <!-- Eureka Client -->
         <dependency>
             <groupId>org.springframework.cloud</groupId>

--- a/simulator-service/src/main/java/com/cookmate/simulator/controller/SimulatorController.java
+++ b/simulator-service/src/main/java/com/cookmate/simulator/controller/SimulatorController.java
@@ -3,7 +3,10 @@ package com.cookmate.simulator.controller;
 import com.cookmate.simulator.dto.HealthCheckResponseDto;
 import com.cookmate.simulator.dto.MealPlanResponseDto;
 import com.cookmate.simulator.dto.RecipeDto;
+import com.cookmate.simulator.dto.SimulationStatusResponseDto;
+import com.cookmate.simulator.dto.SimulationStepHistoryItemDto;
 import com.cookmate.simulator.service.SimulationService;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -37,5 +40,45 @@ public class SimulatorController {
     @GetMapping("/health-check")
     public ResponseEntity<HealthCheckResponseDto> serviceHealthCheck() {
         return ResponseEntity.ok(simulationService.serviceHealthCheck());
+    }
+
+    @PostMapping("/sessions/start")
+    public ResponseEntity<SimulationStatusResponseDto> startSimulation(@RequestParam(required = false) Integer days) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(simulationService.start(days));
+    }
+
+    @GetMapping("/sessions/{sessionId}/status")
+    public ResponseEntity<SimulationStatusResponseDto> getSimulationStatus(@PathVariable String sessionId) {
+        return ResponseEntity.ok(simulationService.getStatus(sessionId));
+    }
+
+    @PostMapping("/sessions/{sessionId}/steps/execute")
+    public ResponseEntity<SimulationStatusResponseDto> executeStep(@PathVariable String sessionId) {
+        return ResponseEntity.ok(simulationService.executeStep(sessionId));
+    }
+
+    @PostMapping("/sessions/{sessionId}/complete")
+    public ResponseEntity<SimulationStatusResponseDto> complete(@PathVariable String sessionId) {
+        return ResponseEntity.ok(simulationService.complete(sessionId));
+    }
+
+    @PostMapping("/sessions/{sessionId}/pause")
+    public ResponseEntity<SimulationStatusResponseDto> pause(@PathVariable String sessionId) {
+        return ResponseEntity.ok(simulationService.pause(sessionId));
+    }
+
+    @PostMapping("/sessions/{sessionId}/resume")
+    public ResponseEntity<SimulationStatusResponseDto> resume(@PathVariable String sessionId) {
+        return ResponseEntity.ok(simulationService.resume(sessionId));
+    }
+
+    @PostMapping("/sessions/{sessionId}/cancel")
+    public ResponseEntity<SimulationStatusResponseDto> cancel(@PathVariable String sessionId) {
+        return ResponseEntity.ok(simulationService.cancel(sessionId));
+    }
+
+    @GetMapping("/sessions/{sessionId}/history")
+    public ResponseEntity<List<SimulationStepHistoryItemDto>> history(@PathVariable String sessionId) {
+        return ResponseEntity.ok(simulationService.history(sessionId));
     }
 }

--- a/simulator-service/src/main/java/com/cookmate/simulator/dto/SimulationStatusResponseDto.java
+++ b/simulator-service/src/main/java/com/cookmate/simulator/dto/SimulationStatusResponseDto.java
@@ -1,0 +1,14 @@
+package com.cookmate.simulator.dto;
+
+import java.util.List;
+
+public record SimulationStatusResponseDto(
+        String sessionId,
+        String status,
+        int currentStep,
+        int totalSteps,
+        int totalRecipes,
+        String message,
+        List<SimulationStepHistoryItemDto> history
+) {
+}

--- a/simulator-service/src/main/java/com/cookmate/simulator/dto/SimulationStepHistoryItemDto.java
+++ b/simulator-service/src/main/java/com/cookmate/simulator/dto/SimulationStepHistoryItemDto.java
@@ -1,0 +1,13 @@
+package com.cookmate.simulator.dto;
+
+import java.time.LocalDateTime;
+
+public record SimulationStepHistoryItemDto(
+        int stepNumber,
+        Long recipeId,
+        String recipeName,
+        String preparationTime,
+        String status,
+        LocalDateTime executedAt
+) {
+}

--- a/simulator-service/src/main/java/com/cookmate/simulator/exception/GlobalExceptionHandler.java
+++ b/simulator-service/src/main/java/com/cookmate/simulator/exception/GlobalExceptionHandler.java
@@ -19,4 +19,26 @@ public class GlobalExceptionHandler {
         );
         return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(errorResponse);
     }
+
+    @ExceptionHandler(SimulationSessionNotFoundException.class)
+    public ResponseEntity<ErrorResponseDto> handleSimulationSessionNotFoundException(
+            SimulationSessionNotFoundException exception
+    ) {
+        ErrorResponseDto errorResponse = new ErrorResponseDto(
+                "SIMULATION_NOT_FOUND",
+                exception.getMessage()
+        );
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
+    }
+
+    @ExceptionHandler(InvalidSimulationStateException.class)
+    public ResponseEntity<ErrorResponseDto> handleInvalidSimulationStateException(
+            InvalidSimulationStateException exception
+    ) {
+        ErrorResponseDto errorResponse = new ErrorResponseDto(
+                "INVALID_SIMULATION_STATE",
+                exception.getMessage()
+        );
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(errorResponse);
+    }
 }

--- a/simulator-service/src/main/java/com/cookmate/simulator/exception/InvalidSimulationStateException.java
+++ b/simulator-service/src/main/java/com/cookmate/simulator/exception/InvalidSimulationStateException.java
@@ -1,0 +1,8 @@
+package com.cookmate.simulator.exception;
+
+public class InvalidSimulationStateException extends RuntimeException {
+
+    public InvalidSimulationStateException(String message) {
+        super(message);
+    }
+}

--- a/simulator-service/src/main/java/com/cookmate/simulator/exception/SimulationSessionNotFoundException.java
+++ b/simulator-service/src/main/java/com/cookmate/simulator/exception/SimulationSessionNotFoundException.java
@@ -1,0 +1,8 @@
+package com.cookmate.simulator.exception;
+
+public class SimulationSessionNotFoundException extends RuntimeException {
+
+    public SimulationSessionNotFoundException(String sessionId) {
+        super("Simulation session not found: " + sessionId);
+    }
+}

--- a/simulator-service/src/main/java/com/cookmate/simulator/model/SimulationSession.java
+++ b/simulator-service/src/main/java/com/cookmate/simulator/model/SimulationSession.java
@@ -1,0 +1,130 @@
+package com.cookmate.simulator.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "simulation_sessions")
+public class SimulationSession {
+
+    @Id
+    @Column(nullable = false, updatable = false, length = 36)
+    private String id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private SimulationStatus status;
+
+    @Column(name = "current_step", nullable = false)
+    private int currentStep;
+
+    @Column(name = "total_steps", nullable = false)
+    private int totalSteps;
+
+    @Column(name = "total_recipes", nullable = false)
+    private int totalRecipes;
+
+    @Column(columnDefinition = "TEXT")
+    private String message;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Column(name = "completed_at")
+    private LocalDateTime completedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        LocalDateTime now = LocalDateTime.now();
+        createdAt = now;
+        updatedAt = now;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public SimulationStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(SimulationStatus status) {
+        this.status = status;
+    }
+
+    public int getCurrentStep() {
+        return currentStep;
+    }
+
+    public void setCurrentStep(int currentStep) {
+        this.currentStep = currentStep;
+    }
+
+    public int getTotalSteps() {
+        return totalSteps;
+    }
+
+    public void setTotalSteps(int totalSteps) {
+        this.totalSteps = totalSteps;
+    }
+
+    public int getTotalRecipes() {
+        return totalRecipes;
+    }
+
+    public void setTotalRecipes(int totalRecipes) {
+        this.totalRecipes = totalRecipes;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    public LocalDateTime getCompletedAt() {
+        return completedAt;
+    }
+
+    public void setCompletedAt(LocalDateTime completedAt) {
+        this.completedAt = completedAt;
+    }
+}

--- a/simulator-service/src/main/java/com/cookmate/simulator/model/SimulationStatus.java
+++ b/simulator-service/src/main/java/com/cookmate/simulator/model/SimulationStatus.java
@@ -1,0 +1,8 @@
+package com.cookmate.simulator.model;
+
+public enum SimulationStatus {
+    RUNNING,
+    PAUSED,
+    COMPLETED,
+    CANCELLED
+}

--- a/simulator-service/src/main/java/com/cookmate/simulator/model/SimulationStep.java
+++ b/simulator-service/src/main/java/com/cookmate/simulator/model/SimulationStep.java
@@ -7,13 +7,24 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "simulation_steps")
+@Table(
+    name = "simulation_steps",
+    indexes = {
+        @Index(name = "idx_simulation_steps_session_step", columnList = "session_id, step_number"),
+        @Index(name = "idx_simulation_steps_session_status", columnList = "session_id, status")
+    },
+    uniqueConstraints = {
+        @UniqueConstraint(name = "uk_simulation_steps_session_step", columnNames = {"session_id", "step_number"})
+    }
+)
 public class SimulationStep {
 
     @Id

--- a/simulator-service/src/main/java/com/cookmate/simulator/model/SimulationStep.java
+++ b/simulator-service/src/main/java/com/cookmate/simulator/model/SimulationStep.java
@@ -1,0 +1,124 @@
+package com.cookmate.simulator.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "simulation_steps")
+public class SimulationStep {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "session_id", nullable = false, length = 36)
+    private String sessionId;
+
+    @Column(name = "step_number", nullable = false)
+    private int stepNumber;
+
+    @Column(name = "recipe_id")
+    private Long recipeId;
+
+    @Column(name = "recipe_name")
+    private String recipeName;
+
+    @Column(name = "preparation_time")
+    private String preparationTime;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private StepStatus status;
+
+    @Column(name = "executed_at")
+    private LocalDateTime executedAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getSessionId() {
+        return sessionId;
+    }
+
+    public void setSessionId(String sessionId) {
+        this.sessionId = sessionId;
+    }
+
+    public int getStepNumber() {
+        return stepNumber;
+    }
+
+    public void setStepNumber(int stepNumber) {
+        this.stepNumber = stepNumber;
+    }
+
+    public Long getRecipeId() {
+        return recipeId;
+    }
+
+    public void setRecipeId(Long recipeId) {
+        this.recipeId = recipeId;
+    }
+
+    public String getRecipeName() {
+        return recipeName;
+    }
+
+    public void setRecipeName(String recipeName) {
+        this.recipeName = recipeName;
+    }
+
+    public String getPreparationTime() {
+        return preparationTime;
+    }
+
+    public void setPreparationTime(String preparationTime) {
+        this.preparationTime = preparationTime;
+    }
+
+    public StepStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(StepStatus status) {
+        this.status = status;
+    }
+
+    public LocalDateTime getExecutedAt() {
+        return executedAt;
+    }
+
+    public void setExecutedAt(LocalDateTime executedAt) {
+        this.executedAt = executedAt;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/simulator-service/src/main/java/com/cookmate/simulator/model/StepStatus.java
+++ b/simulator-service/src/main/java/com/cookmate/simulator/model/StepStatus.java
@@ -1,0 +1,7 @@
+package com.cookmate.simulator.model;
+
+public enum StepStatus {
+    PENDING,
+    EXECUTED,
+    SKIPPED
+}

--- a/simulator-service/src/main/java/com/cookmate/simulator/repository/SimulationSessionRepository.java
+++ b/simulator-service/src/main/java/com/cookmate/simulator/repository/SimulationSessionRepository.java
@@ -1,0 +1,9 @@
+package com.cookmate.simulator.repository;
+
+import com.cookmate.simulator.model.SimulationSession;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SimulationSessionRepository extends JpaRepository<SimulationSession, String> {
+}

--- a/simulator-service/src/main/java/com/cookmate/simulator/repository/SimulationStepRepository.java
+++ b/simulator-service/src/main/java/com/cookmate/simulator/repository/SimulationStepRepository.java
@@ -2,7 +2,9 @@ package com.cookmate.simulator.repository;
 
 import com.cookmate.simulator.model.SimulationStep;
 import com.cookmate.simulator.model.StepStatus;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -13,6 +15,7 @@ public interface SimulationStepRepository extends JpaRepository<SimulationStep, 
 
     List<SimulationStep> findBySessionIdOrderByStepNumberAsc(String sessionId);
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     Optional<SimulationStep> findFirstBySessionIdAndStatusOrderByStepNumberAsc(String sessionId, StepStatus status);
 
     long countBySessionIdAndStatus(String sessionId, StepStatus status);

--- a/simulator-service/src/main/java/com/cookmate/simulator/repository/SimulationStepRepository.java
+++ b/simulator-service/src/main/java/com/cookmate/simulator/repository/SimulationStepRepository.java
@@ -1,0 +1,19 @@
+package com.cookmate.simulator.repository;
+
+import com.cookmate.simulator.model.SimulationStep;
+import com.cookmate.simulator.model.StepStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface SimulationStepRepository extends JpaRepository<SimulationStep, Long> {
+
+    List<SimulationStep> findBySessionIdOrderByStepNumberAsc(String sessionId);
+
+    Optional<SimulationStep> findFirstBySessionIdAndStatusOrderByStepNumberAsc(String sessionId, StepStatus status);
+
+    long countBySessionIdAndStatus(String sessionId, StepStatus status);
+}

--- a/simulator-service/src/main/java/com/cookmate/simulator/service/SimulationService.java
+++ b/simulator-service/src/main/java/com/cookmate/simulator/service/SimulationService.java
@@ -6,32 +6,52 @@ import com.cookmate.simulator.dto.HealthCheckResponseDto;
 import com.cookmate.simulator.dto.MealPlanItemDto;
 import com.cookmate.simulator.dto.MealPlanResponseDto;
 import com.cookmate.simulator.dto.RecipeDto;
+import com.cookmate.simulator.dto.SimulationStatusResponseDto;
+import com.cookmate.simulator.dto.SimulationStepHistoryItemDto;
+import com.cookmate.simulator.exception.InvalidSimulationStateException;
 import com.cookmate.simulator.exception.MainServiceCommunicationException;
+import com.cookmate.simulator.exception.SimulationSessionNotFoundException;
 import com.cookmate.simulator.model.HealthStatus;
+import com.cookmate.simulator.model.SimulationSession;
+import com.cookmate.simulator.model.SimulationStatus;
+import com.cookmate.simulator.model.SimulationStep;
+import com.cookmate.simulator.model.StepStatus;
+import com.cookmate.simulator.repository.SimulationSessionRepository;
+import com.cookmate.simulator.repository.SimulationStepRepository;
 import feign.FeignException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import java.util.UUID;
 import java.util.function.Supplier;
 
 @Service
 public class SimulationService {
 
     private static final String EMPTY_RECIPES_MESSAGE = "No recipes available. Please add recipes to main-service first.";
+    private static final String ONLY_RUNNING_ALLOWED = "Only RUNNING simulation can execute steps.";
 
     private final MainServiceClient mainServiceClient;
     private final SimulationProperties simulationProperties;
+    private final SimulationSessionRepository simulationSessionRepository;
+    private final SimulationStepRepository simulationStepRepository;
     private final Random random;
 
     public SimulationService(
             MainServiceClient mainServiceClient,
             SimulationProperties simulationProperties,
+            SimulationSessionRepository simulationSessionRepository,
+            SimulationStepRepository simulationStepRepository,
             Random random
     ) {
         this.mainServiceClient = mainServiceClient;
         this.simulationProperties = simulationProperties;
+        this.simulationSessionRepository = simulationSessionRepository;
+        this.simulationStepRepository = simulationStepRepository;
         this.random = random;
     }
 
@@ -63,6 +83,145 @@ public class SimulationService {
         }
 
         return new MealPlanResponseDto(days, recipes.size(), null, plan);
+    }
+
+    @Transactional
+    public SimulationStatusResponseDto start(Integer requestedDays) {
+        int days = normalizeDays(requestedDays);
+        List<RecipeDto> recipes = listRecipes();
+
+        SimulationSession session = new SimulationSession();
+        session.setId(UUID.randomUUID().toString());
+        session.setCurrentStep(0);
+        session.setTotalRecipes(recipes.size());
+
+        if (recipes.isEmpty()) {
+            session.setStatus(SimulationStatus.COMPLETED);
+            session.setTotalSteps(0);
+            session.setMessage(EMPTY_RECIPES_MESSAGE);
+            session.setCompletedAt(LocalDateTime.now());
+            simulationSessionRepository.save(session);
+            return mapStatusResponse(session, List.of());
+        }
+
+        session.setStatus(SimulationStatus.RUNNING);
+        session.setTotalSteps(days);
+        session.setMessage(null);
+        simulationSessionRepository.save(session);
+
+        List<SimulationStep> steps = new ArrayList<>(days);
+        for (int step = 1; step <= days; step++) {
+            RecipeDto recipe = recipes.get(random.nextInt(recipes.size()));
+
+            SimulationStep simulationStep = new SimulationStep();
+            simulationStep.setSessionId(session.getId());
+            simulationStep.setStepNumber(step);
+            simulationStep.setRecipeId(recipe.getId());
+            simulationStep.setRecipeName(recipe.getName());
+            simulationStep.setPreparationTime(formatPreparationTime(recipe.getPreparationTimeMinutes()));
+            simulationStep.setStatus(StepStatus.PENDING);
+
+            steps.add(simulationStep);
+        }
+
+        simulationStepRepository.saveAll(steps);
+        return mapStatusResponse(session, steps);
+    }
+
+    public SimulationStatusResponseDto getStatus(String sessionId) {
+        SimulationSession session = getSessionOrThrow(sessionId);
+        List<SimulationStep> steps = simulationStepRepository.findBySessionIdOrderByStepNumberAsc(sessionId);
+        return mapStatusResponse(session, steps);
+    }
+
+    @Transactional
+    public SimulationStatusResponseDto executeStep(String sessionId) {
+        SimulationSession session = getSessionOrThrow(sessionId);
+        validateState(session, SimulationStatus.RUNNING, ONLY_RUNNING_ALLOWED);
+
+        SimulationStep nextStep = simulationStepRepository
+                .findFirstBySessionIdAndStatusOrderByStepNumberAsc(sessionId, StepStatus.PENDING)
+                .orElse(null);
+
+        if (nextStep == null) {
+            completeInternal(session);
+            return getStatus(sessionId);
+        }
+
+        nextStep.setStatus(StepStatus.EXECUTED);
+        nextStep.setExecutedAt(LocalDateTime.now());
+        simulationStepRepository.save(nextStep);
+
+        session.setCurrentStep(session.getCurrentStep() + 1);
+        simulationSessionRepository.save(session);
+
+        if (session.getCurrentStep() >= session.getTotalSteps()) {
+            completeInternal(session);
+        }
+
+        return getStatus(sessionId);
+    }
+
+    @Transactional
+    public SimulationStatusResponseDto complete(String sessionId) {
+        SimulationSession session = getSessionOrThrow(sessionId);
+
+        if (session.getStatus() == SimulationStatus.CANCELLED) {
+            throw new InvalidSimulationStateException("Cancelled simulation cannot be completed.");
+        }
+        if (session.getStatus() == SimulationStatus.COMPLETED) {
+            return getStatus(sessionId);
+        }
+        if (session.getStatus() != SimulationStatus.RUNNING && session.getStatus() != SimulationStatus.PAUSED) {
+            throw new InvalidSimulationStateException("Only RUNNING or PAUSED simulation can be completed.");
+        }
+
+        completeInternal(session);
+        return getStatus(sessionId);
+    }
+
+    @Transactional
+    public SimulationStatusResponseDto pause(String sessionId) {
+        SimulationSession session = getSessionOrThrow(sessionId);
+        validateState(session, SimulationStatus.RUNNING, "Only RUNNING simulation can be paused.");
+
+        session.setStatus(SimulationStatus.PAUSED);
+        simulationSessionRepository.save(session);
+        return getStatus(sessionId);
+    }
+
+    @Transactional
+    public SimulationStatusResponseDto resume(String sessionId) {
+        SimulationSession session = getSessionOrThrow(sessionId);
+        validateState(session, SimulationStatus.PAUSED, "Only PAUSED simulation can be resumed.");
+
+        session.setStatus(SimulationStatus.RUNNING);
+        simulationSessionRepository.save(session);
+        return getStatus(sessionId);
+    }
+
+    @Transactional
+    public SimulationStatusResponseDto cancel(String sessionId) {
+        SimulationSession session = getSessionOrThrow(sessionId);
+
+        if (session.getStatus() == SimulationStatus.CANCELLED) {
+            return getStatus(sessionId);
+        }
+        if (session.getStatus() == SimulationStatus.COMPLETED) {
+            throw new InvalidSimulationStateException("Completed simulation cannot be cancelled.");
+        }
+
+        markPendingAsSkipped(sessionId);
+        session.setStatus(SimulationStatus.CANCELLED);
+        session.setCompletedAt(LocalDateTime.now());
+        simulationSessionRepository.save(session);
+
+        return getStatus(sessionId);
+    }
+
+    public List<SimulationStepHistoryItemDto> history(String sessionId) {
+        getSessionOrThrow(sessionId);
+        return mapHistory(simulationStepRepository.findBySessionIdOrderByStepNumberAsc(sessionId));
     }
 
     public HealthCheckResponseDto serviceHealthCheck() {
@@ -107,5 +266,69 @@ public class SimulationService {
             return "Connection failed";
         }
         return exception.getMessage();
+    }
+
+    private SimulationSession getSessionOrThrow(String sessionId) {
+        return simulationSessionRepository.findById(sessionId)
+                .orElseThrow(() -> new SimulationSessionNotFoundException(sessionId));
+    }
+
+    private void validateState(SimulationSession session, SimulationStatus expectedStatus, String message) {
+        if (session.getStatus() != expectedStatus) {
+            throw new InvalidSimulationStateException(message);
+        }
+    }
+
+    private void completeInternal(SimulationSession session) {
+        markPendingAsSkipped(session.getId());
+        session.setStatus(SimulationStatus.COMPLETED);
+        session.setCompletedAt(LocalDateTime.now());
+        simulationSessionRepository.save(session);
+    }
+
+    private void markPendingAsSkipped(String sessionId) {
+        List<SimulationStep> steps = simulationStepRepository.findBySessionIdOrderByStepNumberAsc(sessionId);
+        LocalDateTime now = LocalDateTime.now();
+
+        for (SimulationStep step : steps) {
+            if (step.getStatus() == StepStatus.PENDING) {
+                step.setStatus(StepStatus.SKIPPED);
+                step.setExecutedAt(now);
+            }
+        }
+
+        simulationStepRepository.saveAll(steps);
+    }
+
+    private SimulationStatusResponseDto mapStatusResponse(SimulationSession session, List<SimulationStep> steps) {
+        long executedSteps = simulationStepRepository.countBySessionIdAndStatus(session.getId(), StepStatus.EXECUTED);
+        int recalculatedCurrentStep = (int) executedSteps;
+        if (session.getCurrentStep() != recalculatedCurrentStep) {
+            session.setCurrentStep(recalculatedCurrentStep);
+            simulationSessionRepository.save(session);
+        }
+
+        return new SimulationStatusResponseDto(
+                session.getId(),
+                session.getStatus().name(),
+                session.getCurrentStep(),
+                session.getTotalSteps(),
+                session.getTotalRecipes(),
+                session.getMessage(),
+                mapHistory(steps)
+        );
+    }
+
+    private List<SimulationStepHistoryItemDto> mapHistory(List<SimulationStep> steps) {
+        return steps.stream()
+                .map(step -> new SimulationStepHistoryItemDto(
+                        step.getStepNumber(),
+                        step.getRecipeId(),
+                        step.getRecipeName(),
+                        step.getPreparationTime(),
+                        step.getStatus().name(),
+                        step.getExecutedAt()
+                ))
+                .toList();
     }
 }

--- a/simulator-service/src/main/java/com/cookmate/simulator/service/SimulationService.java
+++ b/simulator-service/src/main/java/com/cookmate/simulator/service/SimulationService.java
@@ -27,10 +27,18 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.function.Supplier;
 
 @Service
 public class SimulationService {
+
+    private final ConcurrentMap<String, Object> sessionExecutionLocks = new ConcurrentHashMap<>();
+
+    private Object getExecutionLock(String sessionId) {
+        return sessionExecutionLocks.computeIfAbsent(sessionId, key -> new Object());
+    }
 
     private static final String EMPTY_RECIPES_MESSAGE = "No recipes available. Please add recipes to main-service first.";
     private static final String ONLY_RUNNING_ALLOWED = "Only RUNNING simulation can execute steps.";
@@ -136,30 +144,32 @@ public class SimulationService {
 
     @Transactional
     public SimulationStatusResponseDto executeStep(String sessionId) {
-        SimulationSession session = getSessionOrThrow(sessionId);
-        validateState(session, SimulationStatus.RUNNING, ONLY_RUNNING_ALLOWED);
+        synchronized (getExecutionLock(sessionId)) {
+            SimulationSession session = getSessionOrThrow(sessionId);
+            validateState(session, SimulationStatus.RUNNING, ONLY_RUNNING_ALLOWED);
 
-        SimulationStep nextStep = simulationStepRepository
-                .findFirstBySessionIdAndStatusOrderByStepNumberAsc(sessionId, StepStatus.PENDING)
-                .orElse(null);
+            SimulationStep nextStep = simulationStepRepository
+                    .findFirstBySessionIdAndStatusOrderByStepNumberAsc(sessionId, StepStatus.PENDING)
+                    .orElse(null);
 
-        if (nextStep == null) {
-            completeInternal(session);
+            if (nextStep == null) {
+                completeInternal(session);
+                return getStatus(sessionId);
+            }
+
+            nextStep.setStatus(StepStatus.EXECUTED);
+            nextStep.setExecutedAt(LocalDateTime.now());
+            simulationStepRepository.save(nextStep);
+
+            session.setCurrentStep(session.getCurrentStep() + 1);
+            simulationSessionRepository.save(session);
+
+            if (session.getCurrentStep() >= session.getTotalSteps()) {
+                completeInternal(session);
+            }
+
             return getStatus(sessionId);
         }
-
-        nextStep.setStatus(StepStatus.EXECUTED);
-        nextStep.setExecutedAt(LocalDateTime.now());
-        simulationStepRepository.save(nextStep);
-
-        session.setCurrentStep(session.getCurrentStep() + 1);
-        simulationSessionRepository.save(session);
-
-        if (session.getCurrentStep() >= session.getTotalSteps()) {
-            completeInternal(session);
-        }
-
-        return getStatus(sessionId);
     }
 
     @Transactional

--- a/simulator-service/src/main/java/com/cookmate/simulator/service/SimulationService.java
+++ b/simulator-service/src/main/java/com/cookmate/simulator/service/SimulationService.java
@@ -21,6 +21,7 @@ import com.cookmate.simulator.repository.SimulationStepRepository;
 import feign.FeignException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -48,19 +49,22 @@ public class SimulationService {
     private final SimulationSessionRepository simulationSessionRepository;
     private final SimulationStepRepository simulationStepRepository;
     private final Random random;
+    private final TransactionTemplate transactionTemplate;
 
     public SimulationService(
             MainServiceClient mainServiceClient,
             SimulationProperties simulationProperties,
             SimulationSessionRepository simulationSessionRepository,
             SimulationStepRepository simulationStepRepository,
-            Random random
+            Random random,
+            TransactionTemplate transactionTemplate
     ) {
         this.mainServiceClient = mainServiceClient;
         this.simulationProperties = simulationProperties;
         this.simulationSessionRepository = simulationSessionRepository;
         this.simulationStepRepository = simulationStepRepository;
         this.random = random;
+        this.transactionTemplate = transactionTemplate;
     }
 
     public List<RecipeDto> listRecipes() {
@@ -93,11 +97,14 @@ public class SimulationService {
         return new MealPlanResponseDto(days, recipes.size(), null, plan);
     }
 
-    @Transactional
     public SimulationStatusResponseDto start(Integer requestedDays) {
         int days = normalizeDays(requestedDays);
         List<RecipeDto> recipes = listRecipes();
 
+        return transactionTemplate.execute(status -> startWithRecipes(days, recipes));
+    }
+
+    private SimulationStatusResponseDto startWithRecipes(int days, List<RecipeDto> recipes) {
         SimulationSession session = new SimulationSession();
         session.setId(UUID.randomUUID().toString());
         session.setCurrentStep(0);

--- a/simulator-service/src/main/java/com/cookmate/simulator/service/SimulationService.java
+++ b/simulator-service/src/main/java/com/cookmate/simulator/service/SimulationService.java
@@ -146,7 +146,31 @@ public class SimulationService {
     public SimulationStatusResponseDto getStatus(String sessionId) {
         SimulationSession session = getSessionOrThrow(sessionId);
         List<SimulationStep> steps = simulationStepRepository.findBySessionIdOrderByStepNumberAsc(sessionId);
-        return mapStatusResponse(session, steps);
+        return mapStatusResponseReadOnly(session, steps);
+    }
+
+    private SimulationStatusResponseDto mapStatusResponseReadOnly(SimulationSession session, List<SimulationStep> steps) {
+        int recalculatedCurrentStep = (int) steps.stream()
+                .filter(step -> step.getStatus() == StepStatus.EXECUTED)
+                .count();
+
+        if (session.getCurrentStep() == recalculatedCurrentStep) {
+            return mapStatusResponse(session, steps);
+        }
+
+        return mapStatusResponse(buildResponseOnlySession(session, recalculatedCurrentStep), steps);
+    }
+
+    private SimulationSession buildResponseOnlySession(SimulationSession session, int currentStep) {
+        SimulationSession responseSession = new SimulationSession();
+        responseSession.setId(session.getId());
+        responseSession.setCurrentStep(currentStep);
+        responseSession.setTotalRecipes(session.getTotalRecipes());
+        responseSession.setStatus(session.getStatus());
+        responseSession.setTotalSteps(session.getTotalSteps());
+        responseSession.setMessage(session.getMessage());
+        responseSession.setCompletedAt(session.getCompletedAt());
+        return responseSession;
     }
 
     @Transactional

--- a/simulator-service/src/main/resources/application.yml
+++ b/simulator-service/src/main/resources/application.yml
@@ -6,6 +6,19 @@ spring:
   threads:
     virtual:
       enabled: true
+  datasource:
+    url: jdbc:postgresql://${DB_HOST:localhost}:5432/${DB_NAME:cookmate}
+    username: ${DB_USER:cookmate}
+    password: ${DB_PASS:cookmate}
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        format_sql: true
 
 # Fallback values (overridden by config-server)
 server:


### PR DESCRIPTION
This pull request introduces persistent simulation sessions to the `simulator-service`, enabling session state and step history to be stored in a PostgreSQL database. The changes include adding new endpoints for session management, updating documentation to reflect the new persistence model, introducing new data models and DTOs, and configuring the service for database connectivity. Exception handling is also enhanced to support the new session logic.

The most important changes are:

**Persistence and Data Model Integration**
* Added PostgreSQL-based persistence for simulation sessions and step history by introducing the `SimulationSession` entity, the `SimulationStatus` enum, and updating configuration files for database connectivity (`application.yml`, `docker-compose.yml`, and Maven dependencies). [[1]](diffhunk://#diff-abe79ea554840b4d0792119804fe55bd92b08c850e2bd267602a154aa7ad3b6bR5-R19) [[2]](diffhunk://#diff-faf7340279f1d900d14fdf6ccdf44d016e8286f9569858450f487e722dd5655eR32-R44) [[3]](diffhunk://#diff-e398077cf045411efe3cafa9ef74364da13e94c26a4939232787165d009e8ea2R1-R130) [[4]](diffhunk://#diff-4add19a84bc166c0a2df6c31d5646e8a297bd79a22888c9678dd307f21fb57b1R1-R8) [[5]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R134-R140) [[6]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L121-R121) [[7]](diffhunk://#diff-b0e3b07cd46afb6ea457e2bdddb1957e5d770bd0ba04f4b5c24004df1668989dR99-R101)
* Updated documentation (`README.md`, `PERSISTENCE.md`) to describe the new persistent session model, data schema, and recovery logic. [[1]](diffhunk://#diff-96fefa291eef11d2112d6e756bc79144a9d39e34f0c5883f4b4538fd4c71fd34L1-R56) [[2]](diffhunk://#diff-b0e3b07cd46afb6ea457e2bdddb1957e5d770bd0ba04f4b5c24004df1668989dR154-R161) [[3]](diffhunk://#diff-b0e3b07cd46afb6ea457e2bdddb1957e5d770bd0ba04f4b5c24004df1668989dR43-R50)

**API Enhancements**
* Introduced new REST endpoints for session lifecycle management: start, status, execute step, pause, resume, complete, cancel, and history retrieval, all mapped in `SimulatorController`. [[1]](diffhunk://#diff-cd09657427889701a1d6897aec5ecbe1f77149666337e18eeeabf62925572629R44-R83) [[2]](diffhunk://#diff-cd09657427889701a1d6897aec5ecbe1f77149666337e18eeeabf62925572629R6-R9) [[3]](diffhunk://#diff-b0e3b07cd46afb6ea457e2bdddb1957e5d770bd0ba04f4b5c24004df1668989dR43-R50)

**DTOs and Exception Handling**
* Added DTOs for simulation status and step history (`SimulationStatusResponseDto`, `SimulationStepHistoryItemDto`). [[1]](diffhunk://#diff-9e517cccf8c1c335920783f7b141ef06799bf561baa5a8defac0b23285c3d350R1-R14) [[2]](diffhunk://#diff-cc8990f2a0ede2f1ac1c700a1838fab093d1982af68bc00ee25b79b8592115e6R1-R13)
* Implemented custom exceptions (`SimulationSessionNotFoundException`, `InvalidSimulationStateException`) and global exception handling for session-related errors. [[1]](diffhunk://#diff-8d4d5ddc15a4eac9a112c75abcb49c6d0664e1a8f49e4223e39ebd3100f16aa6R1-R8) [[2]](diffhunk://#diff-7ac902c34dc9cafca8b0721b4755ddf5167b842726f5965ce01236184c01f274R1-R8) [[3]](diffhunk://#diff-377a50ae3bae7a46f32258d90fbb5a460831373890f519c6cbdc2f20b57288a8R22-R43)

These changes collectively enable the simulator service to support robust, recoverable simulation sessions with full persistence and clear API contracts for session management.