### PR TITLE
Add Step API, service, exception and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ cd simulator-service && mvn spring-boot:run
 | GET    | `/api/recipes`        | Lista wszystkich przepisów|
 | GET    | `/api/recipes?name=X` | Szukaj przepisu po nazwie|
 | GET    | `/api/recipes/{id}`   | Pobierz przepis           |
-| GET    | `/steps/{stepId}`     | Pobierz pojedynczy krok   |
+| GET    | `/api/steps/{stepId}`     | Pobierz pojedynczy krok   |
 | POST   | `/api/recipes`        | Utwórz przepis            |
 | PUT    | `/api/recipes/{id}`   | Zaktualizuj przepis       |
 | DELETE | `/api/recipes/{id}`   | Usuń przepis              |

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ cd simulator-service && mvn spring-boot:run
 | GET    | `/api/recipes`        | Lista wszystkich przepisów|
 | GET    | `/api/recipes?name=X` | Szukaj przepisu po nazwie|
 | GET    | `/api/recipes/{id}`   | Pobierz przepis           |
+| GET    | `/steps/{stepId}`     | Pobierz pojedynczy krok   |
 | POST   | `/api/recipes`        | Utwórz przepis            |
 | PUT    | `/api/recipes/{id}`   | Zaktualizuj przepis       |
 | DELETE | `/api/recipes/{id}`   | Usuń przepis              |

--- a/main-service/MAIN_SERVICE_README.md
+++ b/main-service/MAIN_SERVICE_README.md
@@ -91,7 +91,17 @@ Metody Pomocnicze:
   * Walidacja null/empty dla każdego z 20 składników.
   * Formatowanie: "Nazwa (Miara)" z poprawną interpunkcją.
 - toDTO(Recipe) → RecipeDTO
-  * Mapowanie encji JPA na niemodyfikowalny rekord wyjściowy.
+   * Mapowanie encji JPA na niemodyfikowalny rekord wyjściowy.
+```
+
+**StepService** (Logika kroków przepisu)
+```
+Lokalizacja: src/main/java/com/cookmate/main/service/StepService.java
+
+Metody Publiczne:
+- getStep(Long stepId) → StepDTO
+  * Pobiera pojedynczy krok na podstawie ID.
+  * Dla nieistniejącego kroku rzuca StepNotFoundException.
 ```
 
 #### Kontrolery
@@ -129,6 +139,15 @@ Metody:
 - GET /list – Pobieranie słowników pomocniczych (?type=a|i|c).
 ```
 
+**StepController**
+```
+Lokalizacja: src/main/java/com/cookmate/main/controller/StepController.java
+Endpoint bazowy: /steps
+
+Metody:
+- GET /{stepId} – Pobieranie pojedynczego kroku (StepDTO).
+```
+
 #### Konfiguracja
 
 **WebClientConfig**
@@ -148,6 +167,8 @@ Lokalizacja: src/main/java/com/cookmate/main/exception/GlobalExceptionHandler.ja
 Obsługa:
 - MethodArgumentNotValidException (HTTP 400)
   * Zwraca błędy walidacji na poziomie pól
+- StepNotFoundException (HTTP 404)
+  * Zwraca informację o braku kroku dla podanego ID
   
 - RuntimeException (HTTP 500)
   * Ogólna obsługa błędów

--- a/main-service/MAIN_SERVICE_README.md
+++ b/main-service/MAIN_SERVICE_README.md
@@ -142,7 +142,7 @@ Metody:
 **StepController**
 ```
 Lokalizacja: src/main/java/com/cookmate/main/controller/StepController.java
-Endpoint bazowy: /steps
+Endpoint bazowy: /api/steps
 
 Metody:
 - GET /{stepId} – Pobieranie pojedynczego kroku (StepDTO).

--- a/main-service/README.md
+++ b/main-service/README.md
@@ -96,6 +96,7 @@ cd simulator-service && mvn spring-boot:run
 | GET    | `/api/recipes`        | Lista wszystkich przepisów|
 | GET    | `/api/recipes?name=X` | Szukaj przepisu po nazwie|
 | GET    | `/api/recipes/{id}`   | Pobierz przepis           |
+| GET    | `/steps/{stepId}`     | Pobierz pojedynczy krok   |
 | POST   | `/api/recipes`        | Utwórz przepis            |
 | PUT    | `/api/recipes/{id}`   | Zaktualizuj przepis       |
 | DELETE | `/api/recipes/{id}`   | Usuń przepis              |

--- a/main-service/README.md
+++ b/main-service/README.md
@@ -96,7 +96,7 @@ cd simulator-service && mvn spring-boot:run
 | GET    | `/api/recipes`        | Lista wszystkich przepisów|
 | GET    | `/api/recipes?name=X` | Szukaj przepisu po nazwie|
 | GET    | `/api/recipes/{id}`   | Pobierz przepis           |
-| GET    | `/steps/{stepId}`     | Pobierz pojedynczy krok   |
+| GET    | `/api/steps/{stepId}` | Pobierz pojedynczy krok   |
 | POST   | `/api/recipes`        | Utwórz przepis            |
 | PUT    | `/api/recipes/{id}`   | Zaktualizuj przepis       |
 | DELETE | `/api/recipes/{id}`   | Usuń przepis              |

--- a/main-service/src/main/java/com/cookmate/main/controller/StepController.java
+++ b/main-service/src/main/java/com/cookmate/main/controller/StepController.java
@@ -1,0 +1,22 @@
+package com.cookmate.main.controller;
+
+import com.cookmate.main.dto.StepDTO;
+import com.cookmate.main.service.StepService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/steps")
+public class StepController {
+
+    private final StepService stepService;
+
+    public StepController(StepService stepService) {
+        this.stepService = stepService;
+    }
+
+    @GetMapping("/{stepId}")
+    public ResponseEntity<StepDTO> getStep(@PathVariable Long stepId) {
+        return ResponseEntity.ok(stepService.getStep(stepId));
+    }
+}

--- a/main-service/src/main/java/com/cookmate/main/controller/StepController.java
+++ b/main-service/src/main/java/com/cookmate/main/controller/StepController.java
@@ -6,7 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/steps")
+@RequestMapping("/api/steps")
 public class StepController {
 
     private final StepService stepService;

--- a/main-service/src/main/java/com/cookmate/main/exception/GlobalExceptionHandler.java
+++ b/main-service/src/main/java/com/cookmate/main/exception/GlobalExceptionHandler.java
@@ -43,6 +43,18 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
     }
 
+    @ExceptionHandler(StepNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleStepNotFoundException(StepNotFoundException ex) {
+        ErrorResponse errorResponse = new ErrorResponse(
+            LocalDateTime.now(),
+            HttpStatus.NOT_FOUND.value(),
+            ex.getMessage(),
+            null
+        );
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
+    }
+
     /**
      * Handle general runtime exceptions.
      *

--- a/main-service/src/main/java/com/cookmate/main/exception/StepNotFoundException.java
+++ b/main-service/src/main/java/com/cookmate/main/exception/StepNotFoundException.java
@@ -1,0 +1,8 @@
+package com.cookmate.main.exception;
+
+public class StepNotFoundException extends RuntimeException {
+
+    public StepNotFoundException(Long stepId) {
+        super("Step with id " + stepId + " not found");
+    }
+}

--- a/main-service/src/main/java/com/cookmate/main/service/StepService.java
+++ b/main-service/src/main/java/com/cookmate/main/service/StepService.java
@@ -1,0 +1,26 @@
+package com.cookmate.main.service;
+
+import com.cookmate.main.dto.StepDTO;
+import com.cookmate.main.exception.StepNotFoundException;
+import com.cookmate.main.mapper.StepMapper;
+import com.cookmate.main.model.Step;
+import com.cookmate.main.repository.StepRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class StepService {
+
+    private final StepRepository stepRepository;
+    private final StepMapper stepMapper;
+
+    public StepService(StepRepository stepRepository, StepMapper stepMapper) {
+        this.stepRepository = stepRepository;
+        this.stepMapper = stepMapper;
+    }
+
+    public StepDTO getStep(Long stepId) {
+        Step step = stepRepository.findById(stepId)
+            .orElseThrow(() -> new StepNotFoundException(stepId));
+        return stepMapper.toDTO(step);
+    }
+}

--- a/main-service/src/test/java/com/cookmate/main/controller/StepControllerTest.java
+++ b/main-service/src/test/java/com/cookmate/main/controller/StepControllerTest.java
@@ -1,0 +1,67 @@
+package com.cookmate.main.controller;
+
+import com.cookmate.main.model.ActionType;
+import com.cookmate.main.model.Step;
+import com.cookmate.main.repository.StepRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class StepControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private StepRepository stepRepository;
+
+    @Test
+    void shouldReturnStepDtoForExistingStep() throws Exception {
+        Step savedStep = stepRepository.save(Step.builder()
+            .stepNumber(3)
+            .description("Mieszaj przez 2 minuty")
+            .action(ActionType.MIX)
+            .parameters("{\"speed\":\"medium\"}")
+            .duration(120)
+            .recipeId("recipe-001")
+            .createdAt(LocalDateTime.now())
+            .build());
+
+        mockMvc.perform(get("/steps/{stepId}", savedStep.getId())
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.id").value(savedStep.getId()))
+            .andExpect(jsonPath("$.stepNumber").value(3))
+            .andExpect(jsonPath("$.description").value("Mieszaj przez 2 minuty"))
+            .andExpect(jsonPath("$.action").value("MIX"))
+            .andExpect(jsonPath("$.parameters").value("{\"speed\":\"medium\"}"))
+            .andExpect(jsonPath("$.duration").value(120))
+            .andExpect(jsonPath("$.recipeId").value("recipe-001"))
+            .andExpect(jsonPath("$.createdAt").exists());
+    }
+
+    @Test
+    void shouldReturn404ForUnknownStep() throws Exception {
+        mockMvc.perform(get("/steps/{stepId}", 999999L))
+            .andExpect(status().isNotFound())
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.timestamp").exists())
+            .andExpect(jsonPath("$.status").value(404))
+            .andExpect(jsonPath("$.message").value("Step with id 999999 not found"));
+    }
+}

--- a/main-service/src/test/java/com/cookmate/main/controller/StepControllerTest.java
+++ b/main-service/src/test/java/com/cookmate/main/controller/StepControllerTest.java
@@ -41,7 +41,7 @@ class StepControllerTest {
             .createdAt(LocalDateTime.now())
             .build());
 
-        mockMvc.perform(get("/steps/{stepId}", savedStep.getId())
+        mockMvc.perform(get("/api/steps/{stepId}", savedStep.getId())
                 .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -57,7 +57,7 @@ class StepControllerTest {
 
     @Test
     void shouldReturn404ForUnknownStep() throws Exception {
-        mockMvc.perform(get("/steps/{stepId}", 999999L))
+        mockMvc.perform(get("/api/steps/{stepId}", 999999L))
             .andExpect(status().isNotFound())
             .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
             .andExpect(jsonPath("$.timestamp").exists())

--- a/main-service/src/test/java/com/cookmate/main/service/StepServiceTest.java
+++ b/main-service/src/test/java/com/cookmate/main/service/StepServiceTest.java
@@ -1,0 +1,76 @@
+package com.cookmate.main.service;
+
+import com.cookmate.main.dto.StepDTO;
+import com.cookmate.main.exception.StepNotFoundException;
+import com.cookmate.main.mapper.StepMapper;
+import com.cookmate.main.model.ActionType;
+import com.cookmate.main.model.Step;
+import com.cookmate.main.repository.StepRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class StepServiceTest {
+
+    @Mock
+    private StepRepository stepRepository;
+
+    @Mock
+    private StepMapper stepMapper;
+
+    @InjectMocks
+    private StepService stepService;
+
+    @Test
+    void shouldReturnStepWhenFound() {
+        Step step = Step.builder()
+            .id(1L)
+            .stepNumber(1)
+            .description("Pokroj cebule")
+            .action(ActionType.CHOP)
+            .recipeId("recipe-123")
+            .duration(60)
+            .createdAt(LocalDateTime.now())
+            .build();
+        StepDTO expectedDto = StepDTO.builder()
+            .id(step.getId())
+            .stepNumber(step.getStepNumber())
+            .description(step.getDescription())
+            .action(step.getAction())
+            .recipeId(step.getRecipeId())
+            .duration(step.getDuration())
+            .createdAt(step.getCreatedAt())
+            .build();
+
+        when(stepRepository.findById(1L)).thenReturn(Optional.of(step));
+        when(stepMapper.toDTO(step)).thenReturn(expectedDto);
+
+        StepDTO result = stepService.getStep(1L);
+
+        assertThat(result).isEqualTo(expectedDto);
+        verify(stepRepository).findById(1L);
+        verify(stepMapper).toDTO(step);
+    }
+
+    @Test
+    void shouldThrowWhenStepNotFound() {
+        when(stepRepository.findById(42L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> stepService.getStep(42L))
+            .isInstanceOf(StepNotFoundException.class)
+            .hasMessage("Step with id 42 not found");
+
+        verify(stepRepository).findById(42L);
+        verifyNoInteractions(stepMapper);
+    }
+}


### PR DESCRIPTION
This pull request introduces a new feature for retrieving individual recipe steps by their ID in the main service. It adds a dedicated endpoint, service logic, exception handling, and comprehensive tests to ensure correct behavior and error reporting.

The most important changes are:

**API & Controller:**
* Added a new REST endpoint `GET /steps/{stepId}` in `StepController` to fetch a single step by its ID. [[1]](diffhunk://#diff-87c82e54d8a39d78f0452ee097ae8e1d032d0d3800e175bf7bed1585f0e341e3R1-R22) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R99) [[3]](diffhunk://#diff-b7881a6a719f82b6c4c03952fef910a60949d00f916790cb651c75192b175c90R99)
* Documented the new endpoint and controller in the service README files. [[1]](diffhunk://#diff-c5afe1985aae4c45ad752e3280d3b4966a93d57161c1790e03dee46d4eed3613R97-R106) [[2]](diffhunk://#diff-c5afe1985aae4c45ad752e3280d3b4966a93d57161c1790e03dee46d4eed3613R142-R150)

**Service Layer:**
* Implemented `StepService` with a `getStep(Long stepId)` method that retrieves a step and throws a `StepNotFoundException` if not found.

**Exception Handling:**
* Added a custom `StepNotFoundException` and global exception handler to return a 404 error with a descriptive message when a step is not found. [[1]](diffhunk://#diff-214f551c39f6ec97b8363d06d5272767004ff105b870b6d227cc400a121c3a32R1-R8) [[2]](diffhunk://#diff-a4ce600e554e1081f68a77fec515e60ec0c17cf88ff1c5fbcddbc3529ad4179cR46-R57) [[3]](diffhunk://#diff-c5afe1985aae4c45ad752e3280d3b4966a93d57161c1790e03dee46d4eed3613R170-R171)

**Testing:**
* Added unit tests for `StepService` and integration tests for `StepController`, covering both successful retrieval and not-found scenarios. [[1]](diffhunk://#diff-2d70849f598bbbd64a69246fa9b5741481a60f1179569972266f117e82dc5ba3R1-R76) [[2]](diffhunk://#diff-e32219ddaa1719fc9016576a10c45560c288131bd3119e4d166ed0d130ba5a4eR1-R67)Introduce support for fetching a single recipe step by ID. Added StepController (/steps/{stepId}), StepService (uses StepRepository and StepMapper) and StepNotFoundException; updated GlobalExceptionHandler to return 404 for missing steps. Includes unit tests for StepService (Mockito) and an integration/controller test for the endpoint, and updates to README files documenting the new endpoint and behavior.