### PR TITLE
147 post generatesteps endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# ==========================================
+# CookMate - Szablon Zmiennych Środowiskowych
+# Skopiuj ten plik jako .env i uzupełnij brakujące wartości.
+# ==========================================
+
+# --- API Keys ---
+# Klucz API do modelu LLM (Załóż darmowe konto na console.groq.com)
+GROQ_API_KEY=your_groq_api_key_here
+
+# --- Baza Danych PostgreSQL (Domyślne wartości dla docker-compose) ---
+DB_HOST=postgres
+DB_NAME=cookmate
+DB_USER=cookmate
+DB_PASS=cookmate

--- a/config-repo/main-service.yml
+++ b/config-repo/main-service.yml
@@ -17,5 +17,8 @@ spring:
         dialect: org.hibernate.dialect.PostgreSQLDialect
         format_sql: true
 
+groq:
+  api-key: ${GROQ_API_KEY:}
+
 main-service:
   greeting: "Welcome to CookMate Main Service"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,10 +98,11 @@ services:
     environment:
       CONFIG_SERVER_URL: http://config-service:8888
       EUREKA_SERVER_URL: http://discovery-service:8761/eureka/
-      DB_HOST: postgres
-      DB_NAME: cookmate
-      DB_USER: cookmate
-      DB_PASS: cookmate
+      DB_HOST: ${DB_HOST}
+      DB_NAME: ${DB_NAME}
+      DB_USER: ${DB_USER}
+      DB_PASS: ${DB_PASS}
+      GROQ_API_KEY: ${GROQ_API_KEY}
     depends_on:
       postgres:
         condition: service_healthy

--- a/main-service/src/main/java/com/cookmate/main/MainServiceApplication.java
+++ b/main-service/src/main/java/com/cookmate/main/MainServiceApplication.java
@@ -3,9 +3,11 @@ package com.cookmate.main;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableDiscoveryClient
+@EnableJpaAuditing
 public class MainServiceApplication {
 
     public static void main(String[] args) {

--- a/main-service/src/main/java/com/cookmate/main/controller/StepController.java
+++ b/main-service/src/main/java/com/cookmate/main/controller/StepController.java
@@ -1,7 +1,11 @@
 package com.cookmate.main.controller;
 
 import com.cookmate.main.dto.StepDTO;
+import com.cookmate.main.dto.StepGenerationRequest;
+import com.cookmate.main.dto.StepGenerationResponse;
 import com.cookmate.main.service.StepService;
+import jakarta.servlet.http.HttpSession;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -18,5 +22,21 @@ public class StepController {
     @GetMapping("/{stepId}")
     public ResponseEntity<StepDTO> getStep(@PathVariable Long stepId) {
         return ResponseEntity.ok(stepService.getStep(stepId));
+    }
+
+    /**
+     * Generuje kroki do przepisu z TheMealDB.
+     * Jeśli kroki już istnieją dla danego mealId, zwraca istniejące.
+     *
+     * @param request żądanie zawierające mealId
+     * @param session sesja HTTP z metadanymi przepisu
+     * @return response z listą kroków
+     */
+    @PostMapping("/generate")
+    public ResponseEntity<StepGenerationResponse> generateSteps(
+            @Valid @RequestBody StepGenerationRequest request,
+            HttpSession session) {
+        StepGenerationResponse response = stepService.generateSteps(request, session);
+        return ResponseEntity.ok(response);
     }
 }

--- a/main-service/src/main/java/com/cookmate/main/controller/StepController.java
+++ b/main-service/src/main/java/com/cookmate/main/controller/StepController.java
@@ -36,7 +36,7 @@ public class StepController {
     public ResponseEntity<StepGenerationResponse> generateSteps(
             @Valid @RequestBody StepGenerationRequest request,
             HttpSession session) {
-        StepGenerationResponse response = stepService.generateSteps(request, session);
+        StepGenerationResponse response = stepService.generateSteps(request);
         return ResponseEntity.ok(response);
     }
 }

--- a/main-service/src/main/java/com/cookmate/main/dto/LLMResponseDTO.java
+++ b/main-service/src/main/java/com/cookmate/main/dto/LLMResponseDTO.java
@@ -1,0 +1,19 @@
+package com.cookmate.main.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+/**
+ * DTO representing the complete LLM response containing generated cooking steps.
+ * Wraps a list of LLMStepDTO objects returned from the LLM service.
+ */
+public record LLMResponseDTO(
+    /**
+     * List of generated cooking steps from LLM.
+     */
+    @NotEmpty(message = "Steps list cannot be empty")
+    @JsonProperty("steps")
+    List<LLMStepDTO> steps
+) {}

--- a/main-service/src/main/java/com/cookmate/main/dto/LLMStepDTO.java
+++ b/main-service/src/main/java/com/cookmate/main/dto/LLMStepDTO.java
@@ -1,0 +1,52 @@
+package com.cookmate.main.dto;
+
+import com.cookmate.main.model.ActionType;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+import java.util.Map;
+
+/**
+ * DTO representing a single cooking step returned from LLM.
+ * Used for parsing the LLM response and creating Step entities.
+ */
+public record LLMStepDTO(
+    /**
+     * Step number in the cooking process (must be positive).
+     */
+    @NotNull(message = "Step number is required")
+    @Positive(message = "Step number must be positive")
+    @JsonProperty("step_number")
+    Integer stepNumber,
+
+    /**
+     * Description of what to do in this step (required, non-blank).
+     */
+    @NotBlank(message = "Step description cannot be blank")
+    String description,
+
+    /**
+     * Type of cooking action for this step.
+     */
+    @NotNull(message = "Action type is required")
+    ActionType action,
+
+    /**
+     * Main ingredient used in this step (optional).
+     */
+    @JsonProperty("main_ingredient")
+    String mainIngredient,
+
+    /**
+     * Duration of this step in minutes (optional).
+     */
+    @JsonProperty("duration_minutes")
+    Integer duration,
+
+    /**
+     * Additional parameters (optional).
+     */
+    Map<String, Object> parameters
+) {}

--- a/main-service/src/main/java/com/cookmate/main/dto/StepDTO.java
+++ b/main-service/src/main/java/com/cookmate/main/dto/StepDTO.java
@@ -26,7 +26,7 @@ public record StepDTO(
         String parameters,
 
         @PositiveOrZero(message = "Czas trwania nie może być wartością ujemną")
-        Integer duration,
+        Integer durationMinutes,
 
         @NotBlank(message = "ID przepisu jest wymagane")
         String recipeId,

--- a/main-service/src/main/java/com/cookmate/main/dto/StepGenerationRequest.java
+++ b/main-service/src/main/java/com/cookmate/main/dto/StepGenerationRequest.java
@@ -1,0 +1,15 @@
+package com.cookmate.main.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * Request DTO for generating steps from a TheMealDB meal.
+ * Contains the meal ID to fetch and generate cooking steps for.
+ */
+public record StepGenerationRequest(
+        /**
+         * TheMealDB meal ID (required, non-blank).
+         */
+        @NotBlank(message = "Meal ID cannot be blank")
+        String mealId
+) {}

--- a/main-service/src/main/java/com/cookmate/main/dto/StepGenerationResponse.java
+++ b/main-service/src/main/java/com/cookmate/main/dto/StepGenerationResponse.java
@@ -1,0 +1,24 @@
+package com.cookmate.main.dto;
+
+import java.util.List;
+
+/**
+ * Response DTO for step generation endpoint.
+ * Contains the generated cooking steps and recipe metadata.
+ */
+public record StepGenerationResponse(
+        /**
+         * Recipe ID (TheMealDB meal ID).
+         */
+        String recipeId,
+
+        /**
+         * Recipe name from theMealDB.
+         */
+        String recipeName,
+
+        /**
+         * List of generated cooking steps.
+         */
+        List<StepDTO> steps
+) {}

--- a/main-service/src/main/java/com/cookmate/main/model/Step.java
+++ b/main-service/src/main/java/com/cookmate/main/model/Step.java
@@ -21,14 +21,14 @@ public class Step {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Version
-    private Long version;
-
     @Column(name = "step_number", nullable = false)
     private Integer stepNumber;
 
     @Column(nullable = false, length = 1000)
     private String description;
+
+    @Column(name = "main_ingredient")
+    private String mainIngredient;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -37,7 +37,8 @@ public class Step {
     @Column(columnDefinition = "TEXT") // Obsługa długich parametrów JSON
     private String parameters;
 
-    private Integer duration; // Czas w sekundach
+    @Column(name = "duration_minutes")
+    private Integer durationMinutes; // Czas w minutach
 
     @Column(name = "recipe_id", nullable = false)
     private String recipeId;

--- a/main-service/src/main/java/com/cookmate/main/service/GroqClient.java
+++ b/main-service/src/main/java/com/cookmate/main/service/GroqClient.java
@@ -1,0 +1,186 @@
+package com.cookmate.main.service;
+
+import com.cookmate.main.dto.LLMResponseDTO;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+import reactor.core.publisher.Mono;
+import reactor.util.retry.Retry;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class GroqClient {
+
+    private static final Logger logger = LoggerFactory.getLogger(GroqClient.class);
+    private static final String GROQ_API_URL = "https://api.groq.com/openai/v1/chat/completions";
+    private static final String MODEL = "llama-3.1-8b-instant";
+    private static final double TEMPERATURE = 0.7;
+
+    private final RestClient restClient;
+    private final ObjectMapper objectMapper;
+    private final String apiKey;
+
+    public GroqClient(RestClient.Builder restClientBuilder, ObjectMapper objectMapper,
+                      @Value("${groq.api-key:}") String apiKey) {
+        this.restClient = restClientBuilder.build();
+        this.objectMapper = objectMapper;
+        this.apiKey = apiKey;
+    }
+
+    public Mono<LLMResponseDTO> generateSteps(String recipeInstructions) {
+        logger.info("Wysyłanie żądania do Groq LLM...");
+
+        return Mono.fromCallable(() -> {
+            String prompt = buildPrompt(recipeInstructions);
+            GroqChatRequest request = new GroqChatRequest(
+                    MODEL,
+                    List.of(new GroqMessage("user", prompt)),
+                    TEMPERATURE,
+                    new JsonResponseFormat("json_object")
+            );
+
+            GroqChatResponse response = restClient.post()
+                    .uri(GROQ_API_URL)
+                    .header("Authorization", "Bearer " + apiKey)
+                    .body(request)
+                    .retrieve()
+                    .body(GroqChatResponse.class);
+
+            return parseAndValidateResponse(response);
+        })
+        .retryWhen(Retry.backoff(5, Duration.ofSeconds(1))
+            .doBeforeRetry(retrySignal -> logger.warn(
+                    "Próba {} ponowienia wywołania Groq API z powodu błędu: {}",
+                    retrySignal.totalRetries() + 1,
+                    retrySignal.failure().getMessage()
+            ))
+        )
+        .doOnError(error -> logger.error("Błąd krytyczny komunikacji z Groq po wyczerpaniu limitu prób: {}", error.getMessage()))
+        .onErrorResume(error -> {
+            logger.error("Błąd Groq, zwracam pustą listę kroków");
+            return Mono.just(new LLMResponseDTO(new ArrayList<>()));
+        });
+    }
+
+    private String buildPrompt(String recipeInstructions) {
+        return """
+                You are an expert culinary assistant for the CookMate system.\s
+                CookMate is a multi-functional cooking device (like a Thermomix) that combines a pot, frying pan, blender, and steamer into one machine.
+
+                YOUR PRIMARY TASK:\s
+                Transform the provided recipe into a "Guided Cooking" experience for ONE device.\s
+                Even if the original recipe requires multiple pots, pans, or an oven, ADAPT it to be done primarily within the CookMate device.\s
+                Use heating, stirring, and blending functions to simulate traditional cooking methods.
+
+                CRITICAL INSTRUCTIONS:
+                1. CONSOLIDATE & ADAPT (MAX 8-10 STEPS): Combine actions. For example, if a recipe says "fry chicken in a pan and boil pasta in a pot", transform it into: "First, fry the chicken in the device, remove it, then boil the pasta in the same bowl using the heating function."
+                2. GROUP SIMILAR ACTIONS: Whenever possible, group identical tasks together. If multiple vegetables need preparation (e.g., onions, garlic, carrots), combine them into a single CHOP or CUT step. If multiple ingredients need to be added to the device, group them into a single pouring/adding step UNLESS the recipe strictly dictates a specific time delay between them.
+                3. DETAILED DESCRIPTIONS: Write long, instructional descriptions. Explain how to set up the device for that specific stage.
+                4. DOMINANT ACTIONS ONLY: Use ONLY ONE from: CUT, CHOP, STIR, MARINATE, BLEND, FRYING_PAN, POT, BAKE, WEIGH, GRILL, WAIT, POUR, MIX.
+                5. PARAMETERS: Always include "temperature" and "speed" (0-10) in the parameters object to guide the device simulator.
+
+                Each step MUST include:
+                - "step_number": sequential integer.
+                - "description": detailed instructions for the device user.
+                - "main_ingredient": string or null.
+                - "action": ONE of the allowed action types.
+                - "parameters": JSON object e.g., {"temperature": 120, "speed": 3}.
+                - "duration_minutes": integer.
+
+                EXAMPLE OF ONE-DEVICE ADAPTATION WITH GROUPED ACTIONS:
+                {
+                  "steps": [
+                    {
+                      "step_number": 1,
+                      "description": "Place the onions, garlic, and carrots into the CookMate bowl. Set the device to CHOP mode at speed 5 to finely dice all the vegetables together for 10 seconds. Then, pour in the oil and select FRYING_PAN mode at 120°C to sauté the vegetable mix until softened.",
+                      "main_ingredient": "vegetables",
+                      "action": "CHOP",
+                      "parameters": {"temperature": 120, "speed": 5},
+                      "duration_minutes": 5
+                    },
+                    {
+                      "step_number": 2,
+                      "description": "Attach the mixing butterfly. Add the chopped meat, spices, and tomato paste all at once to the sautéed vegetables. Set the temperature to 140°C and use STIR mode to brown the ingredients evenly.",
+                      "main_ingredient": "meat",
+                      "action": "STIR",
+                      "parameters": {"temperature": 140, "speed": 2},
+                      "duration_minutes": 10
+                    },
+                    {
+                      "step_number": 3,
+                      "description": "Pour the water, broth, and pasta directly into the bowl. Set the temperature to 100°C and let the device simmer in POT mode until the pasta absorbs the liquid and becomes tender.",
+                      "main_ingredient": "pasta",
+                      "action": "POT",
+                      "parameters": {"temperature": 100, "speed": 1},
+                      "duration_minutes": 12
+                    }
+                  ]
+                }
+
+                Recipe to adapt for CookMate:
+                %s
+               """ + recipeInstructions;
+    }
+
+    private LLMResponseDTO parseAndValidateResponse(GroqChatResponse response) {
+        try {
+            String content = response.choices().get(0).message().content().trim();
+            logger.info("Odpowiedź z Groq otrzymana, parsowanie JSON...");
+
+            LLMResponseDTO parsed = objectMapper.readValue(content, LLMResponseDTO.class);
+            if (parsed.steps() == null || parsed.steps().isEmpty()) {
+                throw new IllegalStateException("LLM zwrócił pustą listę kroków.");
+            }
+
+            for (var step : parsed.steps()) {
+                if (step.action() == null) {
+                    throw new IllegalStateException("Krok nr " + step.stepNumber() + " nie zawiera obowiązkowego pola action (null).");
+                }
+                if (step.description() == null || step.description().isBlank()) {
+                    throw new IllegalStateException("Krok nr " + step.stepNumber() + " nie zawiera opisu.");
+                }
+            }
+            logger.info("Pomyślnie sparsowano {} kroków", parsed.steps().size());
+            return parsed;
+        } catch (Exception e) {
+            logger.warn("Walidacja/Parsowanie LLM oblało test: {}. Zgłaszam do ponowienia...", e.getMessage());
+            throw new RuntimeException("Błąd walidacji danych z LLM", e);
+        }
+    }
+
+    // DTO records for Groq API communication
+    public record GroqChatRequest(
+            String model,
+            List<GroqMessage> messages,
+            double temperature,
+            JsonResponseFormat response_format
+    ) {}
+
+    public record JsonResponseFormat(
+            String type
+    ) {}
+
+    public record GroqMessage(
+            String role,
+            String content
+    ) {}
+
+    public record GroqChatResponse(
+            List<GroqChoice> choices
+    ) {}
+
+    public record GroqChoice(
+            GroqChatMessage message
+    ) {}
+
+    public record GroqChatMessage(
+            String role,
+            String content
+    ) {}
+}

--- a/main-service/src/main/java/com/cookmate/main/service/StepService.java
+++ b/main-service/src/main/java/com/cookmate/main/service/StepService.java
@@ -1,14 +1,24 @@
 package com.cookmate.main.service;
 
 import com.cookmate.main.dto.StepDTO;
+import com.cookmate.main.dto.StepGenerationRequest;
+import com.cookmate.main.dto.StepGenerationResponse;
 import com.cookmate.main.exception.StepNotFoundException;
 import com.cookmate.main.mapper.StepMapper;
 import com.cookmate.main.model.Step;
 import com.cookmate.main.repository.StepRepository;
+import jakarta.servlet.http.HttpSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class StepService {
+
+    private static final Logger logger = LoggerFactory.getLogger(StepService.class);
 
     private final StepRepository stepRepository;
     private final StepMapper stepMapper;
@@ -22,5 +32,39 @@ public class StepService {
         Step step = stepRepository.findById(stepId)
             .orElseThrow(() -> new StepNotFoundException(stepId));
         return stepMapper.toDTO(step);
+    }
+
+    /**
+     * Generuje kroki do przepisu z TheMealDB.
+     * Jeśli kroki już istnieją dla danego mealId, zwraca istniejące.
+     * W przeciwnym razie loguje i zwraca pusty response (placeholder dla LLM).
+     *
+     * @param request żądanie z mealId
+     * @param session sesja HTTP zawierająca metadane przepisu
+     * @return response z listą kroków i metadanymi
+     */
+    public StepGenerationResponse generateSteps(StepGenerationRequest request, HttpSession session) {
+        String mealId = request.mealId();
+
+        // 1. Sprawdz czy kroki juz istnieja
+        List<Step> existingSteps = stepRepository.findByRecipeIdOrderByStepNumber(mealId);
+        
+        if (!existingSteps.isEmpty()) {
+            logger.info("Zwracanie istniejących kroków dla mealId: {}", mealId);
+            List<StepDTO> stepDTOs = existingSteps.stream()
+                .map(stepMapper::toDTO)
+                .collect(Collectors.toList());
+            
+            String recipeName = (String) session.getAttribute("recipeName");
+            return new StepGenerationResponse(mealId, recipeName, stepDTOs);
+        }
+        
+        // 2. Kroki nie istnieją - zalogować i placeholder dla LLM
+        logger.info("Brak istniejących kroków dla mealId: {}. TODO: Integracja z Hugging Face LLM", mealId);
+        logger.debug("Metadane przepisu z sesji: recipeName={}", session.getAttribute("recipeName"));
+        
+        // 3. Na razie zwrócić pusty response z metadanymi
+        String recipeName = (String) session.getAttribute("recipeName");
+        return new StepGenerationResponse(mealId, recipeName, List.of());
     }
 }

--- a/main-service/src/main/java/com/cookmate/main/service/StepService.java
+++ b/main-service/src/main/java/com/cookmate/main/service/StepService.java
@@ -7,26 +7,27 @@ import com.cookmate.main.exception.StepNotFoundException;
 import com.cookmate.main.mapper.StepMapper;
 import com.cookmate.main.model.Step;
 import com.cookmate.main.repository.StepRepository;
-import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.ObjectMapper;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
+@RequiredArgsConstructor
 public class StepService {
 
     private static final Logger logger = LoggerFactory.getLogger(StepService.class);
 
     private final StepRepository stepRepository;
     private final StepMapper stepMapper;
-
-    public StepService(StepRepository stepRepository, StepMapper stepMapper) {
-        this.stepRepository = stepRepository;
-        this.stepMapper = stepMapper;
-    }
+    private final MealDbClient mealDbClient;
+    private final GroqClient groqClient;
+    private final ObjectMapper objectMapper;
 
     public StepDTO getStep(Long stepId) {
         Step step = stepRepository.findById(stepId)
@@ -37,34 +38,88 @@ public class StepService {
     /**
      * Generuje kroki do przepisu z TheMealDB.
      * Jeśli kroki już istnieją dla danego mealId, zwraca istniejące.
-     * W przeciwnym razie loguje i zwraca pusty response (placeholder dla LLM).
+     * W przeciwnym razie pobiera przepis z TheMealDB, wysyła do LLM i zapisuje kroki.
      *
      * @param request żądanie z mealId
-     * @param session sesja HTTP zawierająca metadane przepisu
      * @return response z listą kroków i metadanymi
      */
-    public StepGenerationResponse generateSteps(StepGenerationRequest request, HttpSession session) {
+    @Transactional
+    public StepGenerationResponse generateSteps(StepGenerationRequest request) {
         String mealId = request.mealId();
-
-        // 1. Sprawdz czy kroki juz istnieja
+        
+        // 1. Sprawdzić czy kroki już istnieją dla tego mealId
         List<Step> existingSteps = stepRepository.findByRecipeIdOrderByStepNumber(mealId);
         
         if (!existingSteps.isEmpty()) {
             logger.info("Zwracanie istniejących kroków dla mealId: {}", mealId);
             List<StepDTO> stepDTOs = existingSteps.stream()
                 .map(stepMapper::toDTO)
-                .collect(Collectors.toList());
+                .toList();
             
-            String recipeName = (String) session.getAttribute("recipeName");
-            return new StepGenerationResponse(mealId, recipeName, stepDTOs);
+            return new StepGenerationResponse(mealId, null, stepDTOs);
         }
         
-        // 2. Kroki nie istnieją - zalogować i placeholder dla LLM
-        logger.info("Brak istniejących kroków dla mealId: {}. TODO: Integracja z Hugging Face LLM", mealId);
-        logger.debug("Metadane przepisu z sesji: recipeName={}", session.getAttribute("recipeName"));
+        // 2. Kroki nie istnieją - pobrać przepis z TheMealDB
+        logger.info("Pobieranie przepisu z TheMealDB dla mealId: {}", mealId);
         
-        // 3. Na razie zwrócić pusty response z metadanymi
-        String recipeName = (String) session.getAttribute("recipeName");
-        return new StepGenerationResponse(mealId, recipeName, List.of());
+        try {
+            var mealResponse = mealDbClient.lookupById(mealId).block();
+            
+            if (mealResponse == null || mealResponse.meals() == null || mealResponse.meals().isEmpty()) {
+                logger.error("Przepis nie znaleziony w TheMealDB dla mealId: {}", mealId);
+                return new StepGenerationResponse(mealId, null, List.of());
+            }
+            
+            var meal = mealResponse.meals().get(0);
+            String recipeInstructions = meal.strInstructions();
+            String recipeName = meal.strMeal();
+            
+            logger.info("Wysyłanie przepisu '{}' do Groq LLM...", recipeName);
+            var llmResponse = groqClient.generateSteps(recipeInstructions).block();
+            
+            if (llmResponse == null || llmResponse.steps().isEmpty()) {
+                logger.warn("LLM zwrócił pustą listę kroków dla mealId: {}", mealId);
+                return new StepGenerationResponse(mealId, recipeName, List.of());
+            }
+            
+            // 3. Zapisać kroki do bazy
+            logger.info("Zapisywanie {} kroków do bazy dla mealId: {}", llmResponse.steps().size(), mealId);
+            List<Step> stepsToSave = llmResponse.steps().stream()
+                .map(llmStep -> Step.builder()
+                    .stepNumber(llmStep.stepNumber())
+                    .description(llmStep.description())
+                    .action(llmStep.action())
+                    .mainIngredient(llmStep.mainIngredient())
+                    .durationMinutes(llmStep.duration())
+                    .parameters(convertParametersToJsonString(llmStep.parameters()))
+                    .recipeId(mealId)
+                    .build())
+                .toList();
+            
+            List<Step> savedSteps = stepRepository.saveAll(stepsToSave);
+            
+            // 4. Zmapować na DTOs i zwrócić
+            List<StepDTO> stepDTOs = savedSteps.stream()
+                .map(stepMapper::toDTO)
+                .toList();
+            
+            return new StepGenerationResponse(mealId, recipeName, stepDTOs);
+            
+        } catch (Exception e) {
+            logger.error("Błąd podczas generowania kroków dla mealId: {}", mealId, e);
+            return new StepGenerationResponse(mealId, null, List.of());
+        }
+    }
+
+    private String convertParametersToJsonString(Object parameters) {
+        if (parameters == null) {
+            return "{}";
+        }
+        try {
+            return objectMapper.writeValueAsString(parameters);
+        } catch (Exception e) {
+            logger.error("Błąd podczas konwersji parametrów urządzenia na JSON", e);
+            return "{}";
+        }
     }
 }


### PR DESCRIPTION
This pull request introduces a new feature for generating guided cooking steps for recipes using a Large Language Model (LLM) via the Groq API. It adds the necessary backend infrastructure, DTOs, service logic, and configuration to support this integration, enabling automatic adaptation of TheMealDB recipes into step-by-step instructions for the CookMate device. Additionally, it refactors the `Step` model and related DTOs to support new fields and aligns naming conventions.

The most important changes are:

**LLM Integration & Step Generation Feature:**
* Added `GroqClient` service, which communicates with the Groq LLM API to generate cooking steps from recipe instructions, including prompt construction, response parsing, error handling, and retries. (`main-service/src/main/java/com/cookmate/main/service/GroqClient.java`)
* Implemented the `generateSteps` endpoint in `StepController` and corresponding service logic in `StepService` to fetch, generate, and persist guided steps for a given TheMealDB recipe. Returns existing steps if already present, otherwise invokes LLM and saves results. (`main-service/src/main/java/com/cookmate/main/controller/StepController.java`, `main-service/src/main/java/com/cookmate/main/service/StepService.java`) [[1]](diffhunk://#diff-87c82e54d8a39d78f0452ee097ae8e1d032d0d3800e175bf7bed1585f0e341e3R26-R41) [[2]](diffhunk://#diff-fefd7050e28d9e19f00074c2db96f9fd5a4e980a6eeaa49a9efeeab3ecb3cb6eR4-R124)

**DTOs & Data Model Updates:**
* Added new DTOs for LLM integration and step generation: `LLMResponseDTO`, `LLMStepDTO`, `StepGenerationRequest`, and `StepGenerationResponse`. These facilitate structured communication between the backend, LLM, and client. (`main-service/src/main/java/com/cookmate/main/dto/LLMResponseDTO.java`, `LLMStepDTO.java`, `StepGenerationRequest.java`, `StepGenerationResponse.java`) [[1]](diffhunk://#diff-4d59d3e3e6aeeb96066f737c40894d624acf46c4af362e3b4c5b2166888f83cfR1-R19) [[2]](diffhunk://#diff-7a0e6fd34e784eff6b61e7464c68a757a62b8b12cc133ce69a0f8d25a533fc97R1-R52) [[3]](diffhunk://#diff-535f63afa1d9c0ddb8671f762877fd6dc99f9ff79c9bcb30bc54c961ed1c2456R1-R15) [[4]](diffhunk://#diff-a25d096c9d45facbcef1b319ebc16b743c1bacaa0365fe47f7d4bc56676d1a3dR1-R24)
* Refactored the `Step` model and `StepDTO` to include `mainIngredient` and rename the duration field to `durationMinutes` for clarity and consistency with the LLM response. (`main-service/src/main/java/com/cookmate/main/model/Step.java`, `StepDTO.java`) [[1]](diffhunk://#diff-b1f94d28e4ebb58314c77f3a616eee51b6a330dc75536d59d38f0616bc900b26L24-R41) [[2]](diffhunk://#diff-592f029073e924ee3414e2b43517f3141839e67e6a5b265c8ed340074606fe12L29-R29)

**Configuration & Environment:**
* Added Groq API key and database credentials to `.env.example` and ensured these are used in `docker-compose.yml` and Spring configuration. (`.env.example`, `docker-compose.yml`, `config-repo/main-service.yml`) [[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR1-R14) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L101-R105) [[3]](diffhunk://#diff-d5ea358c0a3bdfd8581e7ed21b439923ea9b1ef158630360b4ff6246e6394241R20-R22)
* Enabled JPA Auditing in `MainServiceApplication`. (`main-service/src/main/java/com/cookmate/main/MainServiceApplication.java`)

These changes collectively enable the CookMate backend to automatically generate and serve guided cooking steps for recipes, leveraging LLM capabilities and supporting future enhancements for smart cooking workflows.