### PR TITLE
Recipe List with Pagination & Steps

### DIFF
--- a/main-service/pom.xml
+++ b/main-service/pom.xml
@@ -122,8 +122,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-webflux</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
         </dependency>
     </dependencies>
 

--- a/main-service/src/main/java/com/cookmate/main/controller/RecipeController.java
+++ b/main-service/src/main/java/com/cookmate/main/controller/RecipeController.java
@@ -4,8 +4,10 @@ import com.cookmate.main.dto.RecipeCreateRequest;
 import com.cookmate.main.dto.RecipeDTO;
 import com.cookmate.main.dto.RecipeListResponse;
 import com.cookmate.main.dto.RecipeUpdateRequest;
+import com.cookmate.main.dto.StepDTO;
 import com.cookmate.main.model.Recipe;
 import com.cookmate.main.service.RecipeService;
+import com.cookmate.main.service.StepService;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -22,28 +24,39 @@ import java.util.List;
 public class RecipeController {
 
     private final RecipeService recipeService;
+    private final StepService stepService;
 
     /**
-     * Construct RecipeController with recipe service.
+     * Construct RecipeController with recipe and step services.
      *
      * @param recipeService service for recipe operations
+     * @param stepService service for step operations
      */
-    public RecipeController(RecipeService recipeService) {
+    public RecipeController(RecipeService recipeService, StepService stepService) {
         this.recipeService = recipeService;
+        this.stepService = stepService;
     }
 
     /**
-     * Get all recipes with optional search by name.
+     * Get all recipes with optional search by name and pagination.
+     * If pagination parameters are not provided, defaults to page=0, size=10.
      *
+     * @param page page number (0-based), default is 0
+     * @param size page size, default is 10
      * @param name optional recipe name filter
-     * @return list of recipes
+     * @return paginated list of recipes
      */
     @GetMapping
-    public ResponseEntity<List<Recipe>> getAll(@RequestParam(required = false) String name) {
+    public ResponseEntity<RecipeListResponse> getAll(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(required = false) String name) {
         if (name != null && !name.isBlank()) {
-            return ResponseEntity.ok(recipeService.findByName(name));
+            // For search results, apply pagination on filtered results
+            return ResponseEntity.ok(recipeService.findByNamePaginated(name, page, size));
         }
-        return ResponseEntity.ok(recipeService.findAll());
+        // Return all recipes with pagination
+        return ResponseEntity.ok(recipeService.findPaginated(page, size));
     }
 
     /**
@@ -71,6 +84,19 @@ public class RecipeController {
         return recipeService.findById(id)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
+    }
+
+    /**
+     * Get all steps for a specific recipe.
+     * Steps are sorted by stepNumber in ascending order.
+     *
+     * @param recipeId the recipe ID (TheMealDB ID or internal recipe identifier)
+     * @return list of steps for the recipe, sorted by stepNumber
+     */
+    @GetMapping("/{recipeId}/steps")
+    public ResponseEntity<List<StepDTO>> getRecipeSteps(@PathVariable String recipeId) {
+        List<StepDTO> steps = stepService.getStepsByRecipeId(recipeId);
+        return ResponseEntity.ok(steps);
     }
 
     /**

--- a/main-service/src/main/java/com/cookmate/main/controller/RecipeController.java
+++ b/main-service/src/main/java/com/cookmate/main/controller/RecipeController.java
@@ -9,8 +9,11 @@ import com.cookmate.main.model.Recipe;
 import com.cookmate.main.service.RecipeService;
 import com.cookmate.main.service.StepService;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -21,6 +24,7 @@ import java.util.List;
  */
 @RestController
 @RequestMapping("/api/recipes")
+@Validated
 public class RecipeController {
 
     private final RecipeService recipeService;
@@ -48,8 +52,8 @@ public class RecipeController {
      */
     @GetMapping
     public ResponseEntity<RecipeListResponse> getAll(
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "0") @Min(0) int page,
+            @RequestParam(defaultValue = "10") @Min(1) @Max(100) int size,
             @RequestParam(required = false) String name) {
         if (name != null && !name.isBlank()) {
             // For search results, apply pagination on filtered results
@@ -68,8 +72,8 @@ public class RecipeController {
      */
     @GetMapping("/paginated")
     public ResponseEntity<RecipeListResponse> getPaginated(
-        @RequestParam(defaultValue = "0") int page,
-        @RequestParam(defaultValue = "10") int size) {
+        @RequestParam(defaultValue = "0") @Min(0) int page,
+        @RequestParam(defaultValue = "10") @Min(1) @Max(100) int size) {
         return ResponseEntity.ok(recipeService.findPaginated(page, size));
     }
 

--- a/main-service/src/main/java/com/cookmate/main/exception/GlobalExceptionHandler.java
+++ b/main-service/src/main/java/com/cookmate/main/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.cookmate.main.exception;
 
+import jakarta.validation.ConstraintViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
@@ -53,6 +54,30 @@ public class GlobalExceptionHandler {
         );
 
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
+    }
+
+    /**
+     * Handle bean validation constraint violations on request parameters.
+     *
+     * @param ex ConstraintViolationException with constraint failures
+     * @return error response with constraint details
+     */
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ErrorResponse> handleConstraintViolationException(ConstraintViolationException ex) {
+        Map<String, String> errors = new HashMap<>();
+        ex.getConstraintViolations().forEach(cv -> {
+            String field = cv.getPropertyPath().toString();
+            errors.put(field, cv.getMessage());
+        });
+
+        ErrorResponse errorResponse = new ErrorResponse(
+            LocalDateTime.now(),
+            HttpStatus.BAD_REQUEST.value(),
+            "Validation failed",
+            errors
+        );
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
     }
 
     /**

--- a/main-service/src/main/java/com/cookmate/main/repository/RecipeRepository.java
+++ b/main-service/src/main/java/com/cookmate/main/repository/RecipeRepository.java
@@ -1,6 +1,8 @@
 package com.cookmate.main.repository;
 
 import com.cookmate.main.model.Recipe;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,4 +12,6 @@ import java.util.List;
 public interface RecipeRepository extends JpaRepository<Recipe, Long> {
 
     List<Recipe> findByNameContainingIgnoreCase(String name);
+
+    Page<Recipe> findByNameContainingIgnoreCase(String name, Pageable pageable);
 }

--- a/main-service/src/main/java/com/cookmate/main/repository/StepRepository.java
+++ b/main-service/src/main/java/com/cookmate/main/repository/StepRepository.java
@@ -14,7 +14,7 @@ public interface StepRepository extends JpaRepository<Step, Long> {
     // Pobiera wszystkie kroki, posortowane rosnąco po numerze kroku
     List<Step> findByRecipeIdOrderByStepNumberAsc(String recipeId);
 
-    // Popiera konkretny krok - upewniając sie że należy do odpowiedniego przepisu
-    //SELECT * FROM steps WHERE recipe_id = ? WHERE id = ? AND recipe_id = ?.
+    // Pobiera konkretny krok - upewniając się, że należy do odpowiedniego przepisu
+    // SELECT * FROM steps WHERE id = ? AND recipe_id = ?.
     Optional<Step> findByIdAndRecipeId(Long id, String recipeId);
 }

--- a/main-service/src/main/java/com/cookmate/main/repository/StepRepository.java
+++ b/main-service/src/main/java/com/cookmate/main/repository/StepRepository.java
@@ -11,9 +11,8 @@ import java.util.Optional;
 @Repository
 public interface StepRepository extends JpaRepository<Step, Long> {
 
-    // Pobiera wszystkie kroki
-    //SELECT * FROM steps WHERE recipe_id = ?
-    List<Step> findByRecipeIdOrderByStepNumber(String recipeId);
+    // Pobiera wszystkie kroki, posortowane rosnąco po numerze kroku
+    List<Step> findByRecipeIdOrderByStepNumberAsc(String recipeId);
 
     // Popiera konkretny krok - upewniając sie że należy do odpowiedniego przepisu
     //SELECT * FROM steps WHERE recipe_id = ? WHERE id = ? AND recipe_id = ?.

--- a/main-service/src/main/java/com/cookmate/main/service/RecipeService.java
+++ b/main-service/src/main/java/com/cookmate/main/service/RecipeService.java
@@ -6,6 +6,7 @@ import com.cookmate.main.repository.RecipeRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
@@ -42,7 +43,7 @@ public class RecipeService {
     }
 
     public RecipeListResponse findByNamePaginated(String name, int page, int size) {
-        Pageable pageable = PageRequest.of(page, size);
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "name"));
         Page<Recipe> recipePage = recipeRepository.findByNameContainingIgnoreCase(name, pageable);
 
         List<RecipeDTO> dtos = recipePage.getContent().stream()
@@ -59,7 +60,7 @@ public class RecipeService {
     }
 
     public RecipeListResponse findPaginated(int page, int size) {
-        Pageable pageable = PageRequest.of(page, size);
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "name"));
         Page<Recipe> recipePage = recipeRepository.findAll(pageable);
 
         List<RecipeDTO> dtos = recipePage.getContent().stream()

--- a/main-service/src/main/java/com/cookmate/main/service/RecipeService.java
+++ b/main-service/src/main/java/com/cookmate/main/service/RecipeService.java
@@ -41,6 +41,23 @@ public class RecipeService {
         return recipeRepository.findByNameContainingIgnoreCase(name);
     }
 
+    public RecipeListResponse findByNamePaginated(String name, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<Recipe> recipePage = recipeRepository.findByNameContainingIgnoreCase(name, pageable);
+
+        List<RecipeDTO> dtos = recipePage.getContent().stream()
+                .map(this::toDTO)
+                .collect(Collectors.toList());
+
+        return new RecipeListResponse(
+                dtos,
+                (int) recipePage.getTotalElements(),
+                page,
+                size,
+                recipePage.getTotalPages()
+        );
+    }
+
     public RecipeListResponse findPaginated(int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
         Page<Recipe> recipePage = recipeRepository.findAll(pageable);

--- a/main-service/src/main/java/com/cookmate/main/service/StepService.java
+++ b/main-service/src/main/java/com/cookmate/main/service/StepService.java
@@ -36,6 +36,20 @@ public class StepService {
     }
 
     /**
+     * Pobiera wszystkie kroki przypisane do konkretnego przepisu.
+     * Kroki są posortowane rosnąco po numerze kroku.
+     *
+     * @param recipeId ID przepisu
+     * @return lista StepDTO dla danego przepisu, posortowana po stepNumber
+     */
+    public List<StepDTO> getStepsByRecipeId(String recipeId) {
+        return stepRepository.findByRecipeIdOrderByStepNumberAsc(recipeId)
+            .stream()
+            .map(stepMapper::toDTO)
+            .collect(Collectors.toList());
+    }
+
+    /**
      * Generuje kroki do przepisu z TheMealDB.
      * Jeśli kroki już istnieją dla danego mealId, zwraca istniejące.
      * W przeciwnym razie pobiera przepis z TheMealDB, wysyła do LLM i zapisuje kroki.
@@ -48,7 +62,7 @@ public class StepService {
         String mealId = request.mealId();
         
         // 1. Sprawdzić czy kroki już istnieją dla tego mealId
-        List<Step> existingSteps = stepRepository.findByRecipeIdOrderByStepNumber(mealId);
+        List<Step> existingSteps = stepRepository.findByRecipeIdOrderByStepNumberAsc(mealId);
         
         if (!existingSteps.isEmpty()) {
             logger.info("Zwracanie istniejących kroków dla mealId: {}", mealId);

--- a/main-service/src/test/java/com/cookmate/main/controller/DiscoveryControllerTest.java
+++ b/main-service/src/test/java/com/cookmate/main/controller/DiscoveryControllerTest.java
@@ -1,52 +1,65 @@
 package com.cookmate.main.controller;
 
+import com.cookmate.main.dto.CategoryResponse;
+import com.cookmate.main.dto.Meal;
+import com.cookmate.main.dto.MealSearchResponse;
+import com.cookmate.main.service.MealDbClient;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import reactor.core.publisher.Mono;
 
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.when;
 
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
-class DiscoveryControllerIT {
+class DiscoveryControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
 
+    @MockitoBean // Nowy standard Spring 4
+    private MealDbClient mealDbClient;
+
     @Test
     void shouldReturnMealsWhenSearchingByName() throws Exception {
-        mockMvc.perform(get("/api/v1/discovery/search")
-                        .param("name", "Arrabiata")
-                        .contentType(MediaType.APPLICATION_JSON))
+        // Tworzymy Meal z 53 argumentami (użyj metody pomocniczej z poprzednich odpowiedzi)
+        Meal meal = createTestMeal("52771", "Arrabiata");
+        MealSearchResponse response = new MealSearchResponse(List.of(meal));
+
+        when(mealDbClient.searchByName("Arrabiata")).thenReturn(Mono.just(response));
+
+        // Obsługa asynchronicznego Mono w MockMvc
+        MvcResult mvcResult = mockMvc.perform(get("/api/v1/discovery/search")
+                        .param("name", "Arrabiata"))
+                .andExpect(request().asyncStarted())
+                .andReturn();
+
+        mockMvc.perform(asyncDispatch(mvcResult))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                // Sprawdzamy czy struktura Recordu jest poprawna w JSON
-                .andExpect(jsonPath("$.meals", notNullValue()))
-                .andExpect(jsonPath("$.meals[0].strMeal", containsStringIgnoringCase("Arrabiata")));
+                .andExpect(jsonPath("$.meals[0].strMeal").value("Arrabiata"));
     }
 
-    @Test
-    void shouldReturnCategories() throws Exception {
-        mockMvc.perform(get("/api/v1/discovery/categories"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.categories", hasSize(greaterThan(0))))
-                .andExpect(jsonPath("$.categories[0].strCategory", notNullValue()));
-    }
-
-    @Test
-    void shouldReturnAreasList() throws Exception {
-        mockMvc.perform(get("/api/v1/discovery/list")
-                        .param("type", "a"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.meals", hasSize(greaterThan(0))))
-                // Sprawdzamy czy na liście jest np. kuchnia włoska lub polska
-                .andExpect(jsonPath("$.meals[*].strArea", hasItem("Italian")));
+    private Meal createTestMeal(String id, String name) {
+        Object[] args = new Object[53];
+        return new Meal(id, name, null, null, null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null, null, null,
+                null, null, null);
     }
 }

--- a/main-service/src/test/java/com/cookmate/main/controller/DiscoveryControllerTest.java
+++ b/main-service/src/test/java/com/cookmate/main/controller/DiscoveryControllerTest.java
@@ -1,5 +1,7 @@
 package com.cookmate.main.controller;
 
+import com.cookmate.main.dto.CategoryResponse;
+import com.cookmate.main.dto.CommonListResponse;
 import com.cookmate.main.dto.Meal;
 import com.cookmate.main.dto.MealSearchResponse;
 import com.cookmate.main.service.MealDbClient;
@@ -34,7 +36,7 @@ class DiscoveryControllerTest {
 
     @Test
     void shouldReturnMealsWhenSearchingByName() throws Exception {
-        // Tworzymy Meal z 53 argumentami (użyj metody pomocniczej z poprzednich odpowiedzi)
+        // Meal record has 53 parameters; use helper to keep test declarations concise
         Meal meal = createTestMeal("52771", "Arrabiata");
         MealSearchResponse response = new MealSearchResponse(List.of(meal));
 
@@ -52,8 +54,42 @@ class DiscoveryControllerTest {
                 .andExpect(jsonPath("$.meals[0].strMeal").value("Arrabiata"));
     }
 
+    @Test
+    void shouldReturnCategoriesFromDiscoveryEndpoint() throws Exception {
+        CategoryResponse.CategoryDTO category = new CategoryResponse.CategoryDTO("1", "Chicken", null, "Chicken dishes");
+        CategoryResponse categoryResponse = new CategoryResponse(List.of(category));
+
+        when(mealDbClient.listFullCategories()).thenReturn(Mono.just(categoryResponse));
+
+        MvcResult mvcResult = mockMvc.perform(get("/api/v1/discovery/categories"))
+                .andExpect(request().asyncStarted())
+                .andReturn();
+
+        mockMvc.perform(asyncDispatch(mvcResult))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.categories[0].strCategory").value("Chicken"));
+    }
+
+    @Test
+    void shouldReturnListByTypeFromDiscoveryEndpoint() throws Exception {
+        CommonListResponse.Item item = new CommonListResponse.Item("Chicken", null, null);
+        CommonListResponse listResponse = new CommonListResponse(List.of(item));
+
+        when(mealDbClient.listAllBy("c")).thenReturn(Mono.just(listResponse));
+
+        MvcResult mvcResult = mockMvc.perform(get("/api/v1/discovery/list")
+                        .param("type", "c"))
+                .andExpect(request().asyncStarted())
+                .andReturn();
+
+        mockMvc.perform(asyncDispatch(mvcResult))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.meals[0].strCategory").value("Chicken"));
+    }
+
     private Meal createTestMeal(String id, String name) {
-        Object[] args = new Object[53];
         return new Meal(id, name, null, null, null, null, null, null, null, null,
                 null, null, null, null, null, null, null, null, null, null,
                 null, null, null, null, null, null, null, null, null, null,

--- a/main-service/src/test/java/com/cookmate/main/controller/DiscoveryControllerTest.java
+++ b/main-service/src/test/java/com/cookmate/main/controller/DiscoveryControllerTest.java
@@ -1,6 +1,5 @@
 package com.cookmate.main.controller;
 
-import com.cookmate.main.dto.CategoryResponse;
 import com.cookmate.main.dto.Meal;
 import com.cookmate.main.dto.MealSearchResponse;
 import com.cookmate.main.service.MealDbClient;

--- a/main-service/src/test/java/com/cookmate/main/controller/RecipeControllerTest.java
+++ b/main-service/src/test/java/com/cookmate/main/controller/RecipeControllerTest.java
@@ -1,0 +1,110 @@
+package com.cookmate.main.controller;
+
+import com.cookmate.main.model.ActionType;
+import com.cookmate.main.model.Recipe;
+import com.cookmate.main.model.Step;
+import com.cookmate.main.repository.RecipeRepository;
+import com.cookmate.main.repository.StepRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.cookmate.main.service.MealDbClient;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class RecipeControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private RecipeRepository recipeRepository;
+
+    @Autowired
+    private StepRepository stepRepository;
+
+    @MockitoBean
+    private MealDbClient mealDbClient;
+
+    @Test
+    void shouldReturnPaginatedRecipesWithMetadata() throws Exception {
+        recipeRepository.save(new Recipe("Apple Pie", "A classic dessert", "apples, flour", "Mix and bake", 60));
+        recipeRepository.save(new Recipe("Banana Bread", "Moist bread", "bananas, flour", "Mix and bake", 50));
+
+        mockMvc.perform(get("/api/recipes")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.recipes").isArray())
+                .andExpect(jsonPath("$.pageNumber").value(0))
+                .andExpect(jsonPath("$.pageSize").value(10))
+                .andExpect(jsonPath("$.totalCount").isNumber())
+                .andExpect(jsonPath("$.totalPages").isNumber());
+    }
+
+    @Test
+    void shouldReturnStepsForRecipeSortedAscending() throws Exception {
+        String recipeId = "test-recipe-abc";
+        stepRepository.save(Step.builder()
+                .stepNumber(3).description("Third step").action(ActionType.MIX)
+                .recipeId(recipeId).durationMinutes(5).createdAt(LocalDateTime.now()).build());
+        stepRepository.save(Step.builder()
+                .stepNumber(1).description("First step").action(ActionType.CHOP)
+                .recipeId(recipeId).durationMinutes(2).createdAt(LocalDateTime.now()).build());
+        stepRepository.save(Step.builder()
+                .stepNumber(2).description("Second step").action(ActionType.STIR)
+                .recipeId(recipeId).durationMinutes(3).createdAt(LocalDateTime.now()).build());
+
+        mockMvc.perform(get("/api/recipes/{recipeId}/steps", recipeId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$.length()").value(3))
+                .andExpect(jsonPath("$[0].stepNumber").value(1))
+                .andExpect(jsonPath("$[1].stepNumber").value(2))
+                .andExpect(jsonPath("$[2].stepNumber").value(3));
+    }
+
+    @Test
+    void shouldReturnEmptyListWhenNoStepsForRecipe() throws Exception {
+        mockMvc.perform(get("/api/recipes/{recipeId}/steps", "recipe-with-no-steps")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$.length()").value(0));
+    }
+
+    @Test
+    void shouldReturn400WhenPageIsNegative() throws Exception {
+        mockMvc.perform(get("/api/recipes")
+                        .param("page", "-1")
+                        .param("size", "10"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void shouldReturn400WhenSizeIsZero() throws Exception {
+        mockMvc.perform(get("/api/recipes")
+                        .param("page", "0")
+                        .param("size", "0"))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/main-service/src/test/java/com/cookmate/main/controller/StepControllerTest.java
+++ b/main-service/src/test/java/com/cookmate/main/controller/StepControllerTest.java
@@ -36,7 +36,7 @@ class StepControllerTest {
             .description("Mieszaj przez 2 minuty")
             .action(ActionType.MIX)
             .parameters("{\"speed\":\"medium\"}")
-            .duration(120)
+            .durationMinutes(120)
             .recipeId("recipe-001")
             .createdAt(LocalDateTime.now())
             .build());
@@ -50,7 +50,7 @@ class StepControllerTest {
             .andExpect(jsonPath("$.description").value("Mieszaj przez 2 minuty"))
             .andExpect(jsonPath("$.action").value("MIX"))
             .andExpect(jsonPath("$.parameters").value("{\"speed\":\"medium\"}"))
-            .andExpect(jsonPath("$.duration").value(120))
+            .andExpect(jsonPath("$.durationMinutes").value(120))
             .andExpect(jsonPath("$.recipeId").value("recipe-001"))
             .andExpect(jsonPath("$.createdAt").exists());
     }

--- a/main-service/src/test/java/com/cookmate/main/mapper/StepMapperTest.java
+++ b/main-service/src/test/java/com/cookmate/main/mapper/StepMapperTest.java
@@ -29,7 +29,7 @@ class StepMapperTest {
                 .description("Krojenie cebuli")
                 .action(ActionType.CHOP)
                 .recipeId("recipe-123")
-                .duration(60)
+                .durationMinutes(60)
                 .parameters("{\"size\": \"small\"}")
                 .createdAt(now)
                 .build();
@@ -45,7 +45,7 @@ class StepMapperTest {
         assertEquals(entity.getDescription(), dto.description());
         assertEquals(entity.getAction(), dto.action());
         assertEquals(entity.getRecipeId(), dto.recipeId());
-        assertEquals(entity.getDuration(), dto.duration());
+        assertEquals(entity.getDurationMinutes(), dto.durationMinutes());
         assertEquals(entity.getParameters(), dto.parameters());
         assertEquals(entity.getCreatedAt(), dto.createdAt());
     }
@@ -58,7 +58,7 @@ class StepMapperTest {
                 .description("Smażenie na patelni")
                 .action(ActionType.FRYING_PAN)
                 .recipeId("recipe-456")
-                .duration(300)
+                .durationMinutes(300)
                 .parameters("{\"temp\": 180}")
                 .build();
 
@@ -72,7 +72,7 @@ class StepMapperTest {
         assertEquals(dto.description(), entity.getDescription());
         assertEquals(dto.action(), entity.getAction());
         assertEquals(dto.recipeId(), entity.getRecipeId());
-        assertEquals(dto.duration(), entity.getDuration());
+        assertEquals(dto.durationMinutes(), entity.getDurationMinutes());
         assertEquals(dto.parameters(), entity.getParameters());
 
         assertNull(entity.getId());

--- a/main-service/src/test/java/com/cookmate/main/repository/StepRepositoryTest.java
+++ b/main-service/src/test/java/com/cookmate/main/repository/StepRepositoryTest.java
@@ -46,7 +46,7 @@ class StepRepositoryTest {
         stepRepository.save(step1);
 
         // when
-        List<Step> results = stepRepository.findByRecipeIdOrderByStepNumber(recipeId);
+        List<Step> results = stepRepository.findByRecipeIdOrderByStepNumberAsc(recipeId);
 
         // then
         assertThat(results).hasSize(2);

--- a/main-service/src/test/java/com/cookmate/main/service/RecipeServiceTest.java
+++ b/main-service/src/test/java/com/cookmate/main/service/RecipeServiceTest.java
@@ -13,6 +13,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import reactor.core.publisher.Mono;
 
 import java.time.LocalDateTime;
@@ -69,8 +70,8 @@ class RecipeServiceTest {
         recipe.setId(10L);
         recipe.setCreatedAt(LocalDateTime.now());
 
-        when(recipeRepository.findAll(eq(PageRequest.of(0, 10))))
-                .thenReturn(new PageImpl<>(List.of(recipe), PageRequest.of(0, 10), 1));
+        when(recipeRepository.findAll(eq(PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "name")))))
+                .thenReturn(new PageImpl<>(List.of(recipe), PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "name")), 1));
 
         RecipeListResponse response = recipeService.findPaginated(0, 10);
 

--- a/main-service/src/test/java/com/cookmate/main/service/StepServiceTest.java
+++ b/main-service/src/test/java/com/cookmate/main/service/StepServiceTest.java
@@ -13,6 +13,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -72,5 +73,32 @@ class StepServiceTest {
 
         verify(stepRepository).findById(42L);
         verifyNoInteractions(stepMapper);
+    }
+
+    @Test
+    void shouldReturnStepsByRecipeIdPreservingRepositoryOrder() {
+        String recipeId = "recipe-999";
+        Step step1 = Step.builder().id(1L).stepNumber(2).description("Second").action(ActionType.STIR)
+            .recipeId(recipeId).durationMinutes(5).createdAt(LocalDateTime.now()).build();
+        Step step2 = Step.builder().id(2L).stepNumber(1).description("First").action(ActionType.CHOP)
+            .recipeId(recipeId).durationMinutes(3).createdAt(LocalDateTime.now()).build();
+
+        StepDTO dto1 = StepDTO.builder().id(1L).stepNumber(2).description("Second").action(ActionType.STIR)
+            .recipeId(recipeId).durationMinutes(5).build();
+        StepDTO dto2 = StepDTO.builder().id(2L).stepNumber(1).description("First").action(ActionType.CHOP)
+            .recipeId(recipeId).durationMinutes(3).build();
+
+        when(stepRepository.findByRecipeIdOrderByStepNumberAsc(recipeId)).thenReturn(List.of(step1, step2));
+        when(stepMapper.toDTO(step1)).thenReturn(dto1);
+        when(stepMapper.toDTO(step2)).thenReturn(dto2);
+
+        List<StepDTO> result = stepService.getStepsByRecipeId(recipeId);
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0)).isEqualTo(dto1);
+        assertThat(result.get(1)).isEqualTo(dto2);
+        verify(stepRepository).findByRecipeIdOrderByStepNumberAsc(recipeId);
+        verify(stepMapper).toDTO(step1);
+        verify(stepMapper).toDTO(step2);
     }
 }

--- a/main-service/src/test/java/com/cookmate/main/service/StepServiceTest.java
+++ b/main-service/src/test/java/com/cookmate/main/service/StepServiceTest.java
@@ -78,15 +78,16 @@ class StepServiceTest {
     @Test
     void shouldReturnStepsByRecipeIdPreservingRepositoryOrder() {
         String recipeId = "recipe-999";
-        Step step1 = Step.builder().id(1L).stepNumber(2).description("Second").action(ActionType.STIR)
-            .recipeId(recipeId).durationMinutes(5).createdAt(LocalDateTime.now()).build();
-        Step step2 = Step.builder().id(2L).stepNumber(1).description("First").action(ActionType.CHOP)
+        // Steps returned by the repository are already sorted ASC by stepNumber
+        Step step1 = Step.builder().id(1L).stepNumber(1).description("First").action(ActionType.CHOP)
             .recipeId(recipeId).durationMinutes(3).createdAt(LocalDateTime.now()).build();
+        Step step2 = Step.builder().id(2L).stepNumber(2).description("Second").action(ActionType.STIR)
+            .recipeId(recipeId).durationMinutes(5).createdAt(LocalDateTime.now()).build();
 
-        StepDTO dto1 = StepDTO.builder().id(1L).stepNumber(2).description("Second").action(ActionType.STIR)
-            .recipeId(recipeId).durationMinutes(5).build();
-        StepDTO dto2 = StepDTO.builder().id(2L).stepNumber(1).description("First").action(ActionType.CHOP)
+        StepDTO dto1 = StepDTO.builder().id(1L).stepNumber(1).description("First").action(ActionType.CHOP)
             .recipeId(recipeId).durationMinutes(3).build();
+        StepDTO dto2 = StepDTO.builder().id(2L).stepNumber(2).description("Second").action(ActionType.STIR)
+            .recipeId(recipeId).durationMinutes(5).build();
 
         when(stepRepository.findByRecipeIdOrderByStepNumberAsc(recipeId)).thenReturn(List.of(step1, step2));
         when(stepMapper.toDTO(step1)).thenReturn(dto1);

--- a/main-service/src/test/java/com/cookmate/main/service/StepServiceTest.java
+++ b/main-service/src/test/java/com/cookmate/main/service/StepServiceTest.java
@@ -39,7 +39,7 @@ class StepServiceTest {
             .description("Pokroj cebule")
             .action(ActionType.CHOP)
             .recipeId("recipe-123")
-            .duration(60)
+            .durationMinutes(60)
             .createdAt(LocalDateTime.now())
             .build();
         StepDTO expectedDto = StepDTO.builder()
@@ -48,7 +48,7 @@ class StepServiceTest {
             .description(step.getDescription())
             .action(step.getAction())
             .recipeId(step.getRecipeId())
-            .duration(step.getDuration())
+            .durationMinutes(step.getDurationMinutes())
             .createdAt(step.getCreatedAt())
             .build();
 


### PR DESCRIPTION
Closes #149 

  1. Stronnicowanie Przepisów ✅
   - GET /api/recipes obsługuje page (default=0) i size (default=10)
   - Response zawiera: recipes, totalCount, pageNumber, pageSize, totalPages
   - Opcjonalne wyszukiwanie po nazwie z paginacją

  2. Pobieranie Kroków ✅
   - GET /api/recipes/{recipeId}/steps zwraca List<StepDTO>
   - Kroki posortowane po stepNumber rosnąco (ASC)
   - Zwraca pustą listę [] jeśli brak kroków

 Wszystkie Pliki Zmodyfikowane
  Repository: 2 pliki
   - ✅ RecipeRepository - dodano findByNameContainingIgnoreCase(String, Pageable)
   - ✅ StepRepository - zmieniono na findByRecipeIdOrderByStepNumberAsc()
  Service: 2 pliki
   - ✅ RecipeService - dodano findByNamePaginated()
   - ✅ StepService - dodano getStepsByRecipeId()
  Controller: 1 plik
   - ✅ RecipeController - paginacja + nowy endpoint /steps