### PR TITLE
169-czyszczenie-stepservice

### DIFF
--- a/main-service/src/main/java/com/cookmate/main/dto/StepDTO.java
+++ b/main-service/src/main/java/com/cookmate/main/dto/StepDTO.java
@@ -8,6 +8,7 @@ import jakarta.validation.constraints.PositiveOrZero;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
+import java.util.Map;
 
 @Builder
 public record StepDTO(
@@ -23,7 +24,7 @@ public record StepDTO(
         @NotNull(message = "Typ akcji jest wymagany")
         ActionType action,
 
-        String parameters,
+        Map<String, Object> parameters,
 
         @PositiveOrZero(message = "Czas trwania nie może być wartością ujemną")
         Integer durationMinutes,

--- a/main-service/src/main/java/com/cookmate/main/model/JsonToMapConverter.java
+++ b/main-service/src/main/java/com/cookmate/main/model/JsonToMapConverter.java
@@ -1,0 +1,43 @@
+package com.cookmate.main.model;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Converter(autoApply = false)
+public class JsonToMapConverter implements AttributeConverter<Map<String, Object>, String> {
+
+    private static final Logger logger = LoggerFactory.getLogger(JsonToMapConverter.class);
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(Map<String, Object> attribute) {
+        if (attribute == null || attribute.isEmpty()) {
+            return "{}";
+        }
+        try {
+            return objectMapper.writeValueAsString(attribute);
+        } catch (Exception e) {
+            logger.error("Błąd podczas konwersji mapy parametrów do JSON", e);
+            return "{}";
+        }
+    }
+
+    @Override
+    public Map<String, Object> convertToEntityAttribute(String dbData) {
+        if (dbData == null || dbData.isBlank()) {
+            return new HashMap<>();
+        }
+        try {
+            return objectMapper.readValue(dbData, new com.fasterxml.jackson.core.type.TypeReference<Map<String, Object>>() {});
+        } catch (Exception e) {
+            logger.error("Błąd podczas konwersji JSON do mapy parametrów", e);
+            return new HashMap<>();
+        }
+    }
+}

--- a/main-service/src/main/java/com/cookmate/main/model/JsonToMapConverter.java
+++ b/main-service/src/main/java/com/cookmate/main/model/JsonToMapConverter.java
@@ -36,8 +36,8 @@ public class JsonToMapConverter implements AttributeConverter<Map<String, Object
         try {
             return objectMapper.readValue(dbData, new com.fasterxml.jackson.core.type.TypeReference<Map<String, Object>>() {});
         } catch (Exception e) {
-            logger.error("Błąd podczas konwersji JSON do mapy parametrów", e);
-            return new HashMap<>();
+            logger.error("Błąd podczas konwersji JSON do mapy parametrów. Niepoprawne dane w bazie: {}", dbData, e);
+            throw new IllegalArgumentException("Niepoprawny JSON w kolumnie mapy parametrów", e);
         }
     }
 }

--- a/main-service/src/main/java/com/cookmate/main/model/Step.java
+++ b/main-service/src/main/java/com/cookmate/main/model/Step.java
@@ -7,6 +7,7 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
+import java.util.Map;
 
 @Data
 @Builder
@@ -34,8 +35,9 @@ public class Step {
     @Column(nullable = false)
     private ActionType action;
 
+    @Convert(converter = JsonToMapConverter.class)
     @Column(columnDefinition = "TEXT") // Obsługa długich parametrów JSON
-    private String parameters;
+    private Map<String, Object> parameters;
 
     @Column(name = "duration_minutes")
     private Integer durationMinutes; // Czas w minutach

--- a/main-service/src/main/java/com/cookmate/main/service/StepService.java
+++ b/main-service/src/main/java/com/cookmate/main/service/StepService.java
@@ -12,7 +12,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import tools.jackson.databind.ObjectMapper;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -27,7 +26,6 @@ public class StepService {
     private final StepMapper stepMapper;
     private final MealDbClient mealDbClient;
     private final GroqClient groqClient;
-    private final ObjectMapper objectMapper;
 
     public StepDTO getStep(Long stepId) {
         Step step = stepRepository.findById(stepId)
@@ -105,7 +103,7 @@ public class StepService {
                     .action(llmStep.action())
                     .mainIngredient(llmStep.mainIngredient())
                     .durationMinutes(llmStep.duration())
-                    .parameters(convertParametersToJsonString(llmStep.parameters()))
+                    .parameters(llmStep.parameters())
                     .recipeId(mealId)
                     .build())
                 .toList();
@@ -122,18 +120,6 @@ public class StepService {
         } catch (Exception e) {
             logger.error("Błąd podczas generowania kroków dla mealId: {}", mealId, e);
             return new StepGenerationResponse(mealId, null, List.of());
-        }
-    }
-
-    private String convertParametersToJsonString(Object parameters) {
-        if (parameters == null) {
-            return "{}";
-        }
-        try {
-            return objectMapper.writeValueAsString(parameters);
-        } catch (Exception e) {
-            logger.error("Błąd podczas konwersji parametrów urządzenia na JSON", e);
-            return "{}";
         }
     }
 }

--- a/main-service/src/main/java/com/cookmate/main/service/StepService.java
+++ b/main-service/src/main/java/com/cookmate/main/service/StepService.java
@@ -13,7 +13,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Service
@@ -103,7 +105,7 @@ public class StepService {
                     .action(llmStep.action())
                     .mainIngredient(llmStep.mainIngredient())
                     .durationMinutes(llmStep.duration())
-                    .parameters(llmStep.parameters())
+                    .parameters(Objects.requireNonNullElseGet(llmStep.parameters(), HashMap::new))
                     .recipeId(mealId)
                     .build())
                 .toList();

--- a/main-service/src/test/java/com/cookmate/main/controller/StepControllerTest.java
+++ b/main-service/src/test/java/com/cookmate/main/controller/StepControllerTest.java
@@ -13,6 +13,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -31,11 +33,14 @@ class StepControllerTest {
 
     @Test
     void shouldReturnStepDtoForExistingStep() throws Exception {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("speed", "medium");
+        
         Step savedStep = stepRepository.save(Step.builder()
             .stepNumber(3)
             .description("Mieszaj przez 2 minuty")
             .action(ActionType.MIX)
-            .parameters("{\"speed\":\"medium\"}")
+            .parameters(parameters)
             .durationMinutes(120)
             .recipeId("recipe-001")
             .createdAt(LocalDateTime.now())
@@ -49,7 +54,6 @@ class StepControllerTest {
             .andExpect(jsonPath("$.stepNumber").value(3))
             .andExpect(jsonPath("$.description").value("Mieszaj przez 2 minuty"))
             .andExpect(jsonPath("$.action").value("MIX"))
-            .andExpect(jsonPath("$.parameters").value("{\"speed\":\"medium\"}"))
             .andExpect(jsonPath("$.durationMinutes").value(120))
             .andExpect(jsonPath("$.recipeId").value("recipe-001"))
             .andExpect(jsonPath("$.createdAt").exists());

--- a/main-service/src/test/java/com/cookmate/main/controller/StepControllerTest.java
+++ b/main-service/src/test/java/com/cookmate/main/controller/StepControllerTest.java
@@ -54,6 +54,8 @@ class StepControllerTest {
             .andExpect(jsonPath("$.stepNumber").value(3))
             .andExpect(jsonPath("$.description").value("Mieszaj przez 2 minuty"))
             .andExpect(jsonPath("$.action").value("MIX"))
+            .andExpect(jsonPath("$.parameters").exists())
+            .andExpect(jsonPath("$.parameters.speed").value("medium"))
             .andExpect(jsonPath("$.durationMinutes").value(120))
             .andExpect(jsonPath("$.recipeId").value("recipe-001"))
             .andExpect(jsonPath("$.createdAt").exists());

--- a/main-service/src/test/java/com/cookmate/main/mapper/StepMapperTest.java
+++ b/main-service/src/test/java/com/cookmate/main/mapper/StepMapperTest.java
@@ -9,6 +9,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -23,6 +25,9 @@ class StepMapperTest {
     void shouldMapStepToDTO() {
         // given
         LocalDateTime now = LocalDateTime.now();
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("size", "small");
+        
         Step entity = Step.builder()
                 .id(1L)
                 .stepNumber(1)
@@ -30,7 +35,7 @@ class StepMapperTest {
                 .action(ActionType.CHOP)
                 .recipeId("recipe-123")
                 .durationMinutes(60)
-                .parameters("{\"size\": \"small\"}")
+                .parameters(parameters)
                 .createdAt(now)
                 .build();
 
@@ -53,13 +58,16 @@ class StepMapperTest {
     @Test
     void shouldMapDTOToEntity() {
         // given
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("temp", 180);
+        
         StepDTO dto = StepDTO.builder()
                 .stepNumber(2)
                 .description("Smażenie na patelni")
                 .action(ActionType.FRYING_PAN)
                 .recipeId("recipe-456")
                 .durationMinutes(300)
-                .parameters("{\"temp\": 180}")
+                .parameters(parameters)
                 .build();
 
         // when


### PR DESCRIPTION
Closes #169 

Zmiany:
- Wprowadzenie JsonToMapConverter: Utworzono konwerter implementujący AttributeConverter, który automatycznie mapuje strukturę Map<String, Object> na format JSON (String) w bazie danych.
- Aktualizacja modelu Step: Zmieniono typ pola parameters ze String na Map<String, Object> oraz dodano adnotację @Convert.
- Zmiana w StepDTO: Pole parameters jest teraz mapą, co pozwala frontendowi otrzymać czysty obiekt JSON zamiast sformatowanego tekstu.
- Odchudzenie StepService: Usunięto ręczne wywołania ObjectMapper oraz metody pomocnicze do konwersji, co uprościło kod serwisu i zmniejszyło liczbę zależności.