### PR TITLE
177 sub issue konfiguracja infrastruktury keycloak docker compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,11 @@ DB_HOST=postgres
 DB_NAME=cookmate
 DB_USER=cookmate
 DB_PASS=cookmate
+
+# --- Keycloak Identity & Access Management ---
+# Admin console: http://localhost:8080/admin
+# Credentials for initial Keycloak setup
+KEYCLOAK_ADMIN=admin
+KEYCLOAK_ADMIN_PASSWORD=admin
+KEYCLOAK_DB_USER=keycloak
+KEYCLOAK_DB_PASSWORD=keycloak

--- a/README.md
+++ b/README.md
@@ -24,9 +24,13 @@ Mikrousługowa architektura aplikacji CookMate do zarządzania przepisami kulina
             │  registers     │  registers      │
             └────────────────┴─────────────────┘
                              │
-                    ┌────────▼────────┐
-                    │   PostgreSQL    │  :5432
-                    └─────────────────┘
+               ┌─────────────┴──────────────┐
+               ▼                            ▼
+       ┌──────────────────┐        ┌─────────────────┐
+       │   PostgreSQL     │        │   Keycloak      │  :8080
+       │  cookmate / auth │        │  (IAM & SSO)    │
+       │     :5432        │        │ (keycloak db)   │
+       └──────────────────┘        └─────────────────┘
 ```
 
 ## Serwisy i porty
@@ -37,6 +41,7 @@ Mikrousługowa architektura aplikacji CookMate do zarządzania przepisami kulina
 | `discovery-service` | 8761 | Eureka Discovery Server                   |
 | `main-service`      | 8081 | REST API zarządzania przepisami + PostgreSQL|
 | `simulator-service` | 8082 | Symulator planowania posiłków (Feign)     |
+| `keycloak`          | 8080 | Keycloak Identity & Access Management     |
 | `postgres`          | 5432 | Baza danych PostgreSQL                    |
 
 ## Stos technologiczny
@@ -65,7 +70,7 @@ docker compose down
 > Jeśli wcześniej był używany wolumen z `postgres:17` lub starszym, wykonaj migrację (`pg_upgrade`) albo zresetuj środowisko developerskie:
 > `docker compose down -v && docker volume rm sumatywny_postgres-data` (lub odpowiedni wolumen dla projektu).
 
-Kolejność startu: **PostgreSQL → Config → Discovery → main-service / simulator-service**
+Kolejność startu: **PostgreSQL → Config → Discovery → main-service / simulator-service → Keycloak**
 
 ### Lokalne uruchomienie (każdy serwis osobno)
 
@@ -123,6 +128,16 @@ GET http://localhost:8888/main-service/default
 GET http://localhost:8888/simulator-service/default
 GET http://localhost:8888/application/default
 ```
+
+### keycloak (`http://localhost:8080`)
+
+Admin console: `http://localhost:8080/admin/master/console/`
+
+**Default credentials:**
+- Username: `admin`
+- Password: `admin`
+
+**Note:** Change default credentials in production. Keycloak uses a separate PostgreSQL database (`keycloak`) for configuration, users, and sessions persistence.
 
 ## Struktura projektu
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ networks:
 
 volumes:
   postgres-data:
+  keycloak-data:
 
 services:
 
@@ -18,10 +19,12 @@ services:
       POSTGRES_DB: cookmate
       POSTGRES_USER: cookmate
       POSTGRES_PASSWORD: cookmate
+      POSTGRES_INITDB_ARGS: "-c max_connections=200"
     ports:
       - "5432:5432"
     volumes:
       - postgres-data:/var/lib/postgresql
+      - ./init-postgres.sql:/docker-entrypoint-initdb.d/01-init.sql:ro
     networks:
       - cookmate-net
     healthcheck:
@@ -149,6 +152,41 @@ services:
       timeout: 10s
       retries: 8
       start_period: 120s
+
+  # ─────────────────────────────────────────────
+  # Keycloak Identity & Access Management (port 8080)
+  # Startup order: after postgres is healthy
+  # ─────────────────────────────────────────────
+  keycloak:
+    image: quay.io/keycloak/keycloak:25.0
+    container_name: cookmate-keycloak
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    environment:
+      KEYCLOAK_ADMIN: "${KEYCLOAK_ADMIN:-admin}"
+      KEYCLOAK_ADMIN_PASSWORD: "${KEYCLOAK_ADMIN_PASSWORD:-admin}"
+      KC_DB: postgres
+      KC_DB_URL: jdbc:postgresql://postgres:5432/keycloak
+      KC_DB_USERNAME: "${KEYCLOAK_DB_USER:-keycloak}"
+      KC_DB_PASSWORD: "${KEYCLOAK_DB_PASSWORD:-keycloak}"
+      KC_HOSTNAME_URL: http://localhost:8080
+      KC_HOSTNAME_ADMIN_URL: http://localhost:8080
+      KC_PROXY: edge
+      KC_HTTP_ENABLED: "true"
+      KC_LOG_LEVEL: INFO
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - cookmate-net
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8080/health/ready || exit 1"]
+      interval: 15s
+      timeout: 10s
+      retries: 8
+      start_period: 60s
+    command: start-dev
 
   # ─────────────────────────────────────────────
   # Frontend Service (port 5173)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,11 +28,11 @@ services:
     networks:
       - cookmate-net
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U cookmate -d cookmate"]
+      test: ["CMD-SHELL", "pg_isready -U cookmate -d cookmate && pg_isready -U keycloak -d keycloak"]
       interval: 10s
       timeout: 5s
-      retries: 5
-      start_period: 20s
+      retries: 8
+      start_period: 40s
 
   # ─────────────────────────────────────────────
   # Config Service (port 8888)
@@ -170,6 +170,7 @@ services:
       KC_DB_URL: jdbc:postgresql://postgres:5432/keycloak
       KC_DB_USERNAME: "${KEYCLOAK_DB_USER:-keycloak}"
       KC_DB_PASSWORD: "${KEYCLOAK_DB_PASSWORD:-keycloak}"
+      KC_DB_URL_PROPERTIES: "?sslmode=disable"
       KC_HOSTNAME_URL: http://localhost:8080
       KC_HOSTNAME_ADMIN_URL: http://localhost:8080
       KC_PROXY: edge
@@ -181,11 +182,11 @@ services:
     networks:
       - cookmate-net
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:8080/health/ready || exit 1"]
-      interval: 15s
+      test: ["CMD-SHELL", "curl -sf http://localhost:8080/ || exit 1"]
+      interval: 30s
       timeout: 10s
-      retries: 8
-      start_period: 60s
+      retries: 5
+      start_period: 90s
     command: start-dev
 
   # ─────────────────────────────────────────────

--- a/init-postgres.sql
+++ b/init-postgres.sql
@@ -1,0 +1,28 @@
+-- ============================================================================
+-- PostgreSQL Initialization Script for CookMate Multi-DB Architecture
+-- ============================================================================
+-- This script initializes the keycloak database and user during postgres 
+-- container startup. It runs automatically when the container starts for 
+-- the first time and creates a separate logical database for Keycloak with
+-- appropriate permissions.
+-- ============================================================================
+
+-- Create keycloak database user (if not exists)
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT FROM pg_user WHERE usename = 'keycloak') THEN
+    CREATE USER keycloak WITH PASSWORD 'keycloak';
+  END IF;
+END $$;
+
+-- Create keycloak database
+CREATE DATABASE keycloak OWNER keycloak ENCODING 'UTF8' TEMPLATE template0;
+
+-- Grant necessary privileges to keycloak user on the database
+GRANT ALL PRIVILEGES ON DATABASE keycloak TO keycloak;
+
+-- Set up default privileges for the keycloak database
+-- This must be done as the database owner or superuser
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL PRIVILEGES ON TABLES TO keycloak;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL PRIVILEGES ON SEQUENCES TO keycloak;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO keycloak;


### PR DESCRIPTION
## Problem:
Potrzebna konfiguracja serwera Keycloak (IAM) w Docker Compose z prawidłowym startem i podłączeniem do bazy PostgreSQL.

## Dodane/modyfikowane pliki:
- init-postgres.sql — skrypt inicjalizacji PostgreSQL, tworzy użytkownika keycloak i bazę danych keycloak z właściwymi uprawnieniami
- docker-compose.yml:
   - Dodana usługa keycloak:25.0 na porcie 8080
   - Keycloak połączony z PostgreSQL (jdbc:postgresql://postgres:5432/keycloak)
   - Prawidłowa sekwencja startu: PostgreSQL - Keycloak (via depends_on)
   - Zdrowotna kontrola PostgreSQL weryfikuje obie bazy danych (cookmate i keycloak)
   - Keycloak ma 90-sekundowy timeout na start bez błędów

- .env.example  - zmienne dla Keycloak (admin, hasło)
- README.md  - architektura, porty, dostęp do konsoli admin

##  Wynik:
http://localhost:8080/admin/master/console/
Login: admin 
Hasło: admin

Closes #177 