### PR TITLE
Add simulator-service tests and test deps

### DIFF
--- a/simulator-service/pom.xml
+++ b/simulator-service/pom.xml
@@ -94,6 +94,16 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webmvc-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/simulator-service/src/test/java/com/cookmate/simulator/client/MainServiceClientTest.java
+++ b/simulator-service/src/test/java/com/cookmate/simulator/client/MainServiceClientTest.java
@@ -1,0 +1,142 @@
+package com.cookmate.simulator.client;
+
+import com.cookmate.simulator.dto.MainServiceStepDto;
+import feign.FeignException;
+import feign.Request;
+import feign.RequestTemplate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Testy MainServiceClient (Feign interface) — weryfikuje zachowanie
+ * przy różnych odpowiedziach z main-service: sukces, 404, 500, błąd sieci.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MainServiceClient — komunikacja z main-service")
+class MainServiceClientTest {
+
+    @Mock
+    private MainServiceClient mainServiceClient;
+
+    // --- getRecipeSteps success ---
+
+    @Test
+    @DisplayName("getRecipeSteps — zwraca listę kroków przy sukcesie")
+    void getRecipeSteps_returnsStepsOnSuccess() {
+        var expected = List.of(
+            new MainServiceStepDto(1L, 1, "Pokrój cebulę", null, 5, "52772"),
+            new MainServiceStepDto(2L, 2, "Podsmaż", null, 10, "52772")
+        );
+        when(mainServiceClient.getRecipeSteps("52772")).thenReturn(expected);
+
+        List<MainServiceStepDto> result = mainServiceClient.getRecipeSteps("52772");
+
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        assertEquals("Pokrój cebulę", result.get(0).description());
+        assertEquals(2, result.get(1).stepNumber());
+        verify(mainServiceClient).getRecipeSteps("52772");
+    }
+
+    @Test
+    @DisplayName("getRecipeSteps — zwraca pustą listę gdy brak kroków")
+    void getRecipeSteps_returnsEmptyList() {
+        when(mainServiceClient.getRecipeSteps("99999")).thenReturn(List.of());
+
+        List<MainServiceStepDto> result = mainServiceClient.getRecipeSteps("99999");
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    // --- getRecipeSteps 404 ---
+
+    @Test
+    @DisplayName("getRecipeSteps — rzuca FeignException.NotFound przy 404")
+    void getRecipeSteps_throwsNotFoundOn404() {
+        Request feignRequest = Request.create(
+            Request.HttpMethod.GET, "/api/recipes/unknown/steps",
+            Collections.emptyMap(), null, new RequestTemplate()
+        );
+        when(mainServiceClient.getRecipeSteps("unknown"))
+            .thenThrow(new FeignException.NotFound("Not Found", feignRequest, null, null));
+
+        FeignException.NotFound ex = assertThrows(FeignException.NotFound.class,
+            () -> mainServiceClient.getRecipeSteps("unknown"));
+
+        assertTrue(ex.getMessage().contains("Not Found"));
+    }
+
+    // --- getRecipeSteps 500 ---
+
+    @Test
+    @DisplayName("getRecipeSteps — rzuca FeignException.InternalServerError przy 500")
+    void getRecipeSteps_throwsOnServerError() {
+        Request feignRequest = Request.create(
+            Request.HttpMethod.GET, "/api/recipes/52772/steps",
+            Collections.emptyMap(), null, new RequestTemplate()
+        );
+        when(mainServiceClient.getRecipeSteps("52772"))
+            .thenThrow(new FeignException.InternalServerError("Internal Server Error", feignRequest, null, null));
+
+        assertThrows(FeignException.InternalServerError.class,
+            () -> mainServiceClient.getRecipeSteps("52772"));
+    }
+
+    // --- network error ---
+
+    @Test
+    @DisplayName("getRecipeSteps — rzuca RuntimeException przy błędzie sieci")
+    void getRecipeSteps_throwsOnNetworkError() {
+        when(mainServiceClient.getRecipeSteps("52772"))
+            .thenThrow(new RuntimeException("Connection refused"));
+
+        RuntimeException ex = assertThrows(RuntimeException.class,
+            () -> mainServiceClient.getRecipeSteps("52772"));
+
+        assertEquals("Connection refused", ex.getMessage());
+    }
+
+    // --- notifyStepCompleted ---
+
+    @Test
+    @DisplayName("notifyStepCompleted — wywołuje POST z poprawnymi danymi")
+    void notifyStepCompleted_sendsCorrectData() {
+        Map<String, Object> event = Map.of(
+            "sessionId", "s-123",
+            "stepNumber", 1,
+            "status", "EXECUTED",
+            "executedAt", "2026-05-18T12:00:00",
+            "recipeId", "r-42"
+        );
+        doNothing().when(mainServiceClient).notifyStepCompleted(event);
+
+        mainServiceClient.notifyStepCompleted(event);
+
+        verify(mainServiceClient).notifyStepCompleted(event);
+    }
+
+    @Test
+    @DisplayName("notifyStepCompleted — rzuca wyjątek przy błędzie serwera")
+    void notifyStepCompleted_throwsOnServerError() {
+        Request feignRequest = Request.create(
+            Request.HttpMethod.POST, "/api/simulation-progress",
+            Collections.emptyMap(), null, new RequestTemplate()
+        );
+        doThrow(new FeignException.InternalServerError("500", feignRequest, null, null))
+            .when(mainServiceClient).notifyStepCompleted(any());
+
+        assertThrows(FeignException.InternalServerError.class,
+            () -> mainServiceClient.notifyStepCompleted(Map.of()));
+    }
+}

--- a/simulator-service/src/test/java/com/cookmate/simulator/controller/SimulationControllerIntegrationTest.java
+++ b/simulator-service/src/test/java/com/cookmate/simulator/controller/SimulationControllerIntegrationTest.java
@@ -1,0 +1,203 @@
+package com.cookmate.simulator.controller;
+
+import com.cookmate.simulator.client.MainServiceClient;
+import com.cookmate.simulator.dto.MainServiceStepDto;
+import com.cookmate.simulator.repository.SimulationSessionRepository;
+import com.cookmate.simulator.repository.SimulationStepRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * Integration test dla SimulatorController — pełny kontekst Spring z H2.
+ * MainServiceClient jest mockowany aby nie łączyć się z main-service.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@DisplayName("SimulatorController — integration tests")
+class SimulationControllerIntegrationTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private SimulationSessionRepository sessionRepo;
+    @Autowired private SimulationStepRepository stepRepo;
+
+    @MockitoBean
+    private MainServiceClient mainServiceClient;
+
+    @BeforeEach
+    void cleanDb() {
+        stepRepo.deleteAll();
+        sessionRepo.deleteAll();
+    }
+
+    // --- POST /api/simulator/sessions/start ---
+
+    @Test
+    @DisplayName("POST /sessions/start — tworzy sesję 201")
+    void startSimulation_returns201() throws Exception {
+        mockMainSteps("52772");
+
+        mockMvc.perform(post("/api/simulator/sessions/start")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"recipeId\":\"52772\"}"))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.sessionId").isNotEmpty())
+            .andExpect(jsonPath("$.status").value("RUNNING"))
+            .andExpect(jsonPath("$.totalSteps").value(2))
+            .andExpect(jsonPath("$.history", hasSize(2)));
+    }
+
+    @Test
+    @DisplayName("POST /sessions/start — 400 gdy brak recipeId")
+    void startSimulation_returns400WhenNoRecipeId() throws Exception {
+        mockMvc.perform(post("/api/simulator/sessions/start")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"recipeId\":\"\"}"))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("POST /sessions/start — 503 gdy main-service niedostępny")
+    void startSimulation_returns503WhenMainDown() throws Exception {
+        when(mainServiceClient.getRecipeSteps("52772"))
+            .thenThrow(new RuntimeException("Connection refused"));
+
+        mockMvc.perform(post("/api/simulator/sessions/start")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"recipeId\":\"52772\"}"))
+            .andExpect(status().isServiceUnavailable())
+            .andExpect(jsonPath("$.code").value("MAIN_SERVICE_UNAVAILABLE"));
+    }
+
+    // --- POST /api/simulator/sessions/{id}/steps/execute ---
+
+    @Test
+    @DisplayName("POST /sessions/{id}/steps/execute — wykonuje krok")
+    void executeNextStep_returns200() throws Exception {
+        String sessionId = createSession("52772");
+
+        mockMvc.perform(post("/api/simulator/sessions/" + sessionId + "/steps/execute"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.stepNumber").value(1));
+    }
+
+    @Test
+    @DisplayName("POST /sessions/{id}/steps/execute — 404 dla nieistniejącej sesji")
+    void executeNextStep_returns404() throws Exception {
+        mockMvc.perform(post("/api/simulator/sessions/nonexistent/steps/execute"))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value("SIMULATION_NOT_FOUND"));
+    }
+
+    // --- POST /api/simulator/sessions/{id}/step ---
+
+    @Test
+    @DisplayName("POST /sessions/{id}/step — przetwarza krok z payloadem")
+    void receiveStep_returns200() throws Exception {
+        String sessionId = createSession("52772");
+        String body = """
+            {"stepNumber":1,"description":"Heat pan","durationSeconds":30}
+            """;
+
+        mockMvc.perform(post("/api/simulator/sessions/" + sessionId + "/step")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true));
+    }
+
+    @Test
+    @DisplayName("POST /sessions/{id}/step — 400 przy nieprawidłowym payloadzie")
+    void receiveStep_returns400OnInvalidPayload() throws Exception {
+        String sessionId = createSession("52772");
+
+        mockMvc.perform(post("/api/simulator/sessions/" + sessionId + "/step")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"stepNumber\":null}"))
+            .andExpect(status().isBadRequest());
+    }
+
+    // --- GET /api/simulator/sessions/{id}/status ---
+
+    @Test
+    @DisplayName("GET /sessions/{id}/status — zwraca status sesji")
+    void getStatus_returns200() throws Exception {
+        String sessionId = createSession("52772");
+
+        mockMvc.perform(get("/api/simulator/sessions/" + sessionId + "/status"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.sessionId").value(sessionId))
+            .andExpect(jsonPath("$.status").value("RUNNING"));
+    }
+
+    @Test
+    @DisplayName("GET /sessions/{id}/status — 404 dla nieistniejącej sesji")
+    void getStatus_returns404() throws Exception {
+        mockMvc.perform(get("/api/simulator/sessions/fake/status"))
+            .andExpect(status().isNotFound());
+    }
+
+    // --- GET /api/simulator/sessions/{id}/history ---
+
+    @Test
+    @DisplayName("GET /sessions/{id}/history — zwraca historię kroków")
+    void getHistory_returns200() throws Exception {
+        String sessionId = createSession("52772");
+
+        mockMvc.perform(get("/api/simulator/sessions/" + sessionId + "/history"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$", hasSize(2)))
+            .andExpect(jsonPath("$[0].status").value("PENDING"));
+    }
+
+    // --- POST /api/simulator/sessions/{id}/rewind ---
+
+    @Test
+    @DisplayName("POST /sessions/{id}/rewind — cofa sesję do kroku")
+    void rewind_returns200() throws Exception {
+        String sessionId = createSession("52772");
+        // Najpierw wykonaj krok
+        mockMvc.perform(post("/api/simulator/sessions/" + sessionId + "/steps/execute"));
+
+        mockMvc.perform(post("/api/simulator/sessions/" + sessionId + "/rewind?stepNumber=0"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.currentStep").value(0))
+            .andExpect(jsonPath("$.status").value("RUNNING"));
+    }
+
+    // --- Helpers ---
+
+    private void mockMainSteps(String recipeId) {
+        when(mainServiceClient.getRecipeSteps(recipeId)).thenReturn(List.of(
+            new MainServiceStepDto(1L, 1, "Pokrój cebulę", null, 5, recipeId),
+            new MainServiceStepDto(2L, 2, "Podsmaż na oleju", null, 10, recipeId)
+        ));
+    }
+
+    private String createSession(String recipeId) throws Exception {
+        mockMainSteps(recipeId);
+        MvcResult result = mockMvc.perform(post("/api/simulator/sessions/start")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"recipeId\":\"" + recipeId + "\"}"))
+            .andExpect(status().isCreated())
+            .andReturn();
+        return objectMapper.readTree(result.getResponse().getContentAsString()).get("sessionId").asText();
+    }
+}

--- a/simulator-service/src/test/java/com/cookmate/simulator/integration/GuidedCookingFlowTest.java
+++ b/simulator-service/src/test/java/com/cookmate/simulator/integration/GuidedCookingFlowTest.java
@@ -1,0 +1,221 @@
+package com.cookmate.simulator.integration;
+
+import com.cookmate.simulator.client.MainServiceClient;
+import com.cookmate.simulator.dto.MainServiceStepDto;
+import com.cookmate.simulator.repository.SimulationSessionRepository;
+import com.cookmate.simulator.repository.SimulationStepRepository;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * End-to-end flow test dla guided cooking:
+ * start → load step 1 → execute → load step 2 → execute → verify completion.
+ *
+ * Symuluje pełny cykl życia sesji gotowania.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@DisplayName("Guided Cooking Flow — end-to-end")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class GuidedCookingFlowTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private SimulationSessionRepository sessionRepo;
+    @Autowired private SimulationStepRepository stepRepo;
+
+    @MockitoBean
+    private MainServiceClient mainServiceClient;
+
+    @BeforeEach
+    void cleanDb() {
+        stepRepo.deleteAll();
+        sessionRepo.deleteAll();
+    }
+
+    @Test
+    @DisplayName("Pełny flow: start → execute step 1 → execute step 2 → COMPLETED")
+    void fullGuidedCookingFlow() throws Exception {
+        // Arrange: main-service zwraca 2 kroki
+        when(mainServiceClient.getRecipeSteps("52772")).thenReturn(List.of(
+            new MainServiceStepDto(1L, 1, "Pokrój warzywa", null, 10, "52772"),
+            new MainServiceStepDto(2L, 2, "Ugotuj w garnku", null, 20, "52772")
+        ));
+
+        // === 1. START — utwórz sesję ===
+        MvcResult startResult = mockMvc.perform(post("/api/simulator/sessions/start")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"recipeId\":\"52772\"}"))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.status").value("RUNNING"))
+            .andExpect(jsonPath("$.totalSteps").value(2))
+            .andExpect(jsonPath("$.currentStep").value(0))
+            .andReturn();
+
+        String sessionId = extractSessionId(startResult);
+        verify(mainServiceClient).getRecipeSteps("52772");
+
+        // === 2. STATUS — sprawdź stan przed wykonaniem ===
+        mockMvc.perform(get("/api/simulator/sessions/" + sessionId + "/status"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status").value("RUNNING"))
+            .andExpect(jsonPath("$.currentStep").value(0))
+            .andExpect(jsonPath("$.history[0].status").value("PENDING"))
+            .andExpect(jsonPath("$.history[1].status").value("PENDING"));
+
+        // === 3. EXECUTE STEP 1 ===
+        mockMvc.perform(post("/api/simulator/sessions/" + sessionId + "/steps/execute"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.stepNumber").value(1));
+
+        // === 4. STATUS po kroku 1 — sprawdź postęp ===
+        mockMvc.perform(get("/api/simulator/sessions/" + sessionId + "/status"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.currentStep").value(1))
+            .andExpect(jsonPath("$.history[0].status").value("EXECUTED"))
+            .andExpect(jsonPath("$.history[1].status").value("PENDING"));
+
+        // === 5. EXECUTE STEP 2 ===
+        mockMvc.perform(post("/api/simulator/sessions/" + sessionId + "/steps/execute"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.stepNumber").value(2));
+
+        // === 6. STATUS — sesja powinna być COMPLETED ===
+        mockMvc.perform(get("/api/simulator/sessions/" + sessionId + "/status"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status").value("COMPLETED"))
+            .andExpect(jsonPath("$.currentStep").value(2))
+            .andExpect(jsonPath("$.history[0].status").value("EXECUTED"))
+            .andExpect(jsonPath("$.history[1].status").value("EXECUTED"));
+
+        // === 7. HISTORY — pełna historia ===
+        mockMvc.perform(get("/api/simulator/sessions/" + sessionId + "/history"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$", hasSize(2)))
+            .andExpect(jsonPath("$[0].stepNumber").value(1))
+            .andExpect(jsonPath("$[0].status").value("EXECUTED"))
+            .andExpect(jsonPath("$[1].stepNumber").value(2))
+            .andExpect(jsonPath("$[1].status").value("EXECUTED"));
+    }
+
+    @Test
+    @DisplayName("Flow z rewind: start → execute → rewind → re-execute → COMPLETED")
+    void flowWithRewind() throws Exception {
+        when(mainServiceClient.getRecipeSteps("52772")).thenReturn(List.of(
+            new MainServiceStepDto(1L, 1, "Krok A", null, 5, "52772"),
+            new MainServiceStepDto(2L, 2, "Krok B", null, 5, "52772")
+        ));
+
+        // Start
+        String sessionId = extractSessionId(
+            mockMvc.perform(post("/api/simulator/sessions/start")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{\"recipeId\":\"52772\"}"))
+                .andExpect(status().isCreated())
+                .andReturn()
+        );
+
+        // Execute step 1
+        mockMvc.perform(post("/api/simulator/sessions/" + sessionId + "/steps/execute"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.stepNumber").value(1));
+
+        // Execute step 2
+        mockMvc.perform(post("/api/simulator/sessions/" + sessionId + "/steps/execute"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.stepNumber").value(2));
+
+        // Verify COMPLETED
+        mockMvc.perform(get("/api/simulator/sessions/" + sessionId + "/status"))
+            .andExpect(jsonPath("$.status").value("COMPLETED"));
+
+        // REWIND to step 1
+        mockMvc.perform(post("/api/simulator/sessions/" + sessionId + "/rewind?stepNumber=1"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status").value("RUNNING"))
+            .andExpect(jsonPath("$.currentStep").value(1));
+
+        // Re-execute step 2
+        mockMvc.perform(post("/api/simulator/sessions/" + sessionId + "/steps/execute"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.stepNumber").value(2));
+
+        // Verify COMPLETED again
+        mockMvc.perform(get("/api/simulator/sessions/" + sessionId + "/status"))
+            .andExpect(jsonPath("$.status").value("COMPLETED"));
+    }
+
+    @Test
+    @DisplayName("Flow z processStep: start → processStep(1) → processStep(2) → COMPLETED")
+    void flowWithProcessStep() throws Exception {
+        when(mainServiceClient.getRecipeSteps("52772")).thenReturn(List.of(
+            new MainServiceStepDto(1L, 1, "Krok 1", null, 5, "52772"),
+            new MainServiceStepDto(2L, 2, "Krok 2", null, 5, "52772")
+        ));
+
+        String sessionId = extractSessionId(
+            mockMvc.perform(post("/api/simulator/sessions/start")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{\"recipeId\":\"52772\"}"))
+                .andExpect(status().isCreated())
+                .andReturn()
+        );
+
+        // processStep 1
+        mockMvc.perform(post("/api/simulator/sessions/" + sessionId + "/step")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"stepNumber\":1,\"description\":\"Exec 1\",\"durationSeconds\":5}"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true));
+
+        // processStep 2
+        mockMvc.perform(post("/api/simulator/sessions/" + sessionId + "/step")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"stepNumber\":2,\"description\":\"Exec 2\",\"durationSeconds\":5}"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true));
+
+        // Verify COMPLETED
+        mockMvc.perform(get("/api/simulator/sessions/" + sessionId + "/status"))
+            .andExpect(jsonPath("$.status").value("COMPLETED"));
+    }
+
+    @Test
+    @DisplayName("Error flow: operacja na nieistniejącej sesji → 404")
+    void errorFlow_sessionNotFound() throws Exception {
+        mockMvc.perform(post("/api/simulator/sessions/fake-id/steps/execute"))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value("SIMULATION_NOT_FOUND"));
+
+        mockMvc.perform(get("/api/simulator/sessions/fake-id/status"))
+            .andExpect(status().isNotFound());
+
+        mockMvc.perform(get("/api/simulator/sessions/fake-id/history"))
+            .andExpect(status().isNotFound());
+    }
+
+    private String extractSessionId(MvcResult result) throws Exception {
+        String json = result.getResponse().getContentAsString();
+        JsonNode node = objectMapper.readTree(json);
+        return node.get("sessionId").asText();
+    }
+}

--- a/simulator-service/src/test/java/com/cookmate/simulator/service/SimulationSessionServiceTest.java
+++ b/simulator-service/src/test/java/com/cookmate/simulator/service/SimulationSessionServiceTest.java
@@ -1,0 +1,195 @@
+package com.cookmate.simulator.service;
+
+import com.cookmate.simulator.client.MainServiceClient;
+import com.cookmate.simulator.dto.*;
+import com.cookmate.simulator.exception.*;
+import com.cookmate.simulator.model.*;
+import com.cookmate.simulator.repository.SimulationSessionRepository;
+import com.cookmate.simulator.repository.SimulationStepRepository;
+import org.junit.jupiter.api.*;
+import org.mockito.*;
+
+import java.time.LocalDateTime;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@DisplayName("SimulationSessionService — komunikacja simulator ↔ main")
+class SimulationSessionServiceTest {
+
+    @Mock private SimulationSessionRepository sessionRepo;
+    @Mock private SimulationStepRepository stepRepo;
+    @Mock private MainServiceClient mainClient;
+    @InjectMocks private SimulationService service;
+
+    private SimulationSession running;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        running = new SimulationSession();
+        running.setId("s-123");
+        running.setStatus(SimulationStatus.RUNNING);
+        running.setCurrentStep(0);
+        running.setTotalSteps(3);
+        running.setRecipeId("r-42");
+        running.setTotalRecipes(1);
+    }
+
+    // --- startSession ---
+
+    @Test
+    @DisplayName("startSession — tworzy sesję i pobiera kroki z main-service")
+    void startSession_createsSessionAndFetchesSteps() {
+        var steps = List.of(
+            new MainServiceStepDto(1L, 1, "Step 1", null, 5, "r-42"),
+            new MainServiceStepDto(2L, 2, "Step 2", null, 3, "r-42")
+        );
+        when(mainClient.getRecipeSteps("r-42")).thenReturn(steps);
+        when(sessionRepo.save(any())).thenAnswer(i -> i.getArgument(0));
+        when(stepRepo.saveAll(any())).thenAnswer(i -> i.getArgument(0));
+
+        var resp = service.startSession(new StartSimulationRequestDto("r-42"));
+
+        assertNotNull(resp.sessionId());
+        assertEquals("RUNNING", resp.status());
+        assertEquals(2, resp.totalSteps());
+        verify(mainClient).getRecipeSteps("r-42");
+        verify(stepRepo).saveAll(any());
+    }
+
+    @Test
+    @DisplayName("startSession — rzuca wyjątek gdy brak kroków")
+    void startSession_throwsWhenNoSteps() {
+        when(mainClient.getRecipeSteps("r-42")).thenReturn(List.of());
+        assertThrows(InvalidSimulationStateException.class,
+            () -> service.startSession(new StartSimulationRequestDto("r-42")));
+    }
+
+    @Test
+    @DisplayName("startSession — rzuca wyjątek gdy main-service niedostępny")
+    void startSession_throwsOnMainServiceError() {
+        when(mainClient.getRecipeSteps("r-42")).thenThrow(new RuntimeException("Connection refused"));
+        var ex = assertThrows(MainServiceCommunicationException.class,
+            () -> service.startSession(new StartSimulationRequestDto("r-42")));
+        assertTrue(ex.getMessage().contains("r-42"));
+    }
+
+    @Test
+    @DisplayName("startSession — rzuca wyjątek przy pustej description")
+    void startSession_throwsOnBlankDescription() {
+        when(mainClient.getRecipeSteps("r-42")).thenReturn(
+            List.of(new MainServiceStepDto(1L, 1, "", null, 5, "r-42")));
+        assertThrows(InvalidSimulationStateException.class,
+            () -> service.startSession(new StartSimulationRequestDto("r-42")));
+    }
+
+    // --- executeNextStep ---
+
+    @Test
+    @DisplayName("executeNextStep — wykonuje PENDING krok")
+    void executeNextStep_executesPendingStep() {
+        var pending = mkStep("s-123", 1, StepStatus.PENDING);
+        when(sessionRepo.findById("s-123")).thenReturn(Optional.of(running));
+        when(stepRepo.findFirstBySessionIdAndStatusOrderByStepNumberAsc("s-123", StepStatus.PENDING))
+            .thenReturn(Optional.of(pending));
+        when(stepRepo.countBySessionIdAndStatus("s-123", StepStatus.PENDING)).thenReturn(2L);
+        when(stepRepo.save(any())).thenAnswer(i -> i.getArgument(0));
+        when(sessionRepo.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        var r = service.executeNextStep("s-123");
+        assertTrue(r.getSuccess());
+        assertEquals(1, r.getStepNumber());
+    }
+
+    @Test
+    @DisplayName("executeNextStep — false gdy brak PENDING")
+    void executeNextStep_falseWhenNoPending() {
+        when(sessionRepo.findById("s-123")).thenReturn(Optional.of(running));
+        when(stepRepo.findFirstBySessionIdAndStatusOrderByStepNumberAsc("s-123", StepStatus.PENDING))
+            .thenReturn(Optional.empty());
+        when(stepRepo.countBySessionIdAndStatus("s-123", StepStatus.PENDING)).thenReturn(0L);
+        when(sessionRepo.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        assertFalse(service.executeNextStep("s-123").getSuccess());
+    }
+
+    @Test
+    @DisplayName("executeNextStep — wyjątek dla nieistniejącej sesji")
+    void executeNextStep_throwsSessionNotFound() {
+        when(sessionRepo.findById("x")).thenReturn(Optional.empty());
+        assertThrows(SimulationSessionNotFoundException.class, () -> service.executeNextStep("x"));
+    }
+
+    @Test
+    @DisplayName("executeNextStep — wyjątek gdy sesja COMPLETED")
+    void executeNextStep_throwsWhenCompleted() {
+        running.setStatus(SimulationStatus.COMPLETED);
+        when(sessionRepo.findById("s-123")).thenReturn(Optional.of(running));
+        assertThrows(InvalidSimulationStateException.class, () -> service.executeNextStep("s-123"));
+    }
+
+    // --- processStep ---
+
+    @Test
+    @DisplayName("processStep — przetwarza krok z sukcesem")
+    void processStep_success() {
+        when(sessionRepo.findById("s-123")).thenReturn(Optional.of(running));
+        when(stepRepo.findBySessionIdAndStepNumber("s-123", 1)).thenReturn(Optional.empty());
+        when(stepRepo.countBySessionIdAndStatus("s-123", StepStatus.PENDING)).thenReturn(2L);
+        when(stepRepo.save(any())).thenAnswer(i -> i.getArgument(0));
+        when(sessionRepo.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        var r = service.processStep("s-123", new RecipeStepRequestDto(1, "Heat pan", 30, "200C", "100g", "note"));
+        assertTrue(r.getSuccess());
+        assertEquals(1, r.getStepNumber());
+    }
+
+    // --- getStatus ---
+
+    @Test
+    @DisplayName("getStatus — wyjątek dla nieistniejącej sesji")
+    void getStatus_throwsNotFound() {
+        when(sessionRepo.findById("x")).thenReturn(Optional.empty());
+        assertThrows(SimulationSessionNotFoundException.class, () -> service.getStatus("x"));
+    }
+
+    @Test
+    @DisplayName("getStatus — zwraca poprawny status")
+    void getStatus_returnsCorrectStatus() {
+        var steps = List.of(mkStep("s-123", 1, StepStatus.EXECUTED), mkStep("s-123", 2, StepStatus.PENDING));
+        when(sessionRepo.findById("s-123")).thenReturn(Optional.of(running));
+        when(stepRepo.findBySessionIdOrderByStepNumberAsc("s-123")).thenReturn(steps);
+        when(sessionRepo.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        var st = service.getStatus("s-123");
+        assertEquals("RUNNING", st.status());
+        assertEquals(1, st.currentStep());
+    }
+
+    // --- rewindToStep ---
+
+    @Test
+    @DisplayName("rewindToStep — cofa sesję")
+    void rewindToStep_rewinds() {
+        var s1 = mkStep("s-123", 1, StepStatus.EXECUTED); s1.setExecutedAt(LocalDateTime.now());
+        var s2 = mkStep("s-123", 2, StepStatus.EXECUTED); s2.setExecutedAt(LocalDateTime.now());
+        when(sessionRepo.findById("s-123")).thenReturn(Optional.of(running));
+        when(stepRepo.findBySessionIdOrderByStepNumberAsc("s-123")).thenReturn(new ArrayList<>(List.of(s1, s2)));
+        when(stepRepo.saveAll(any())).thenAnswer(i -> i.getArgument(0));
+        when(sessionRepo.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        var r = service.rewindToStep("s-123", 1);
+        assertEquals(1, r.currentStep());
+        assertEquals("RUNNING", r.status());
+    }
+
+    private SimulationStep mkStep(String sid, int num, StepStatus status) {
+        var s = new SimulationStep();
+        s.setSessionId(sid); s.setStepNumber(num); s.setStatus(status);
+        s.setRecipeName("Step " + num); s.setPreparationTime(num + " min");
+        return s;
+    }
+}

--- a/simulator-service/src/test/resources/application-test.yml
+++ b/simulator-service/src/test/resources/application-test.yml
@@ -1,17 +1,24 @@
 spring:
   datasource:
-    url: jdbc:h2:mem:testdb
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL
     driver-class-name: org.h2.Driver
     username: sa
     password:
   jpa:
-    database-platform: org.hibernate.dialect.H2Dialect
     hibernate:
       ddl-auto: create-drop
     show-sql: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
   h2:
     console:
       enabled: true
+  cloud:
+    discovery:
+      enabled: false
+    config:
+      enabled: false
 
 server:
   port: 0
@@ -21,3 +28,7 @@ management:
     web:
       exposure:
         include: health
+
+eureka:
+  client:
+    enabled: false


### PR DESCRIPTION
# Issue #14: Testy komunikacji Simulator ↔ Main

## 📌 Cel

Utworzenie testów end-to-end dla synchronicznej komunikacji między `simulator-service` a `main-service`. Weryfikacja poprawnego przebiegu pobierania kroków przepisu i potwierdzania akcji.

---

## 📦 Utworzone artefakty

### 1. `SimulationSessionServiceTest.java`

**Ścieżka:** [SimulationSessionServiceTest.java](file:///c:/Users/lukas_1b707ym/Documents/Studia/Semestr_6/CookMate/simulator-service/src/test/java/com/cookmate/simulator/service/SimulationSessionServiceTest.java)

Testy jednostkowe `SimulationService` z mockowanym `MainServiceClient` (`@Mock` / `@InjectMocks`).

| Test | Opis |
|---|---|
| `startSession_createsSessionAndFetchesSteps` | Tworzy sesję, pobiera kroki z main-service, weryfikuje status RUNNING |
| `startSession_throwsWhenNoSteps` | Rzuca `InvalidSimulationStateException` gdy przepis nie ma kroków |
| `startSession_throwsOnMainServiceError` | Rzuca `MainServiceCommunicationException` gdy main-service niedostępny |
| `startSession_throwsOnBlankDescription` | Walidacja — pusta description w kroku |
| `executeNextStep_executesPendingStep` | Wykonuje następny PENDING krok, zmienia status na EXECUTED |
| `executeNextStep_falseWhenNoPending` | Zwraca `success=false` gdy nie ma PENDING kroków |
| `executeNextStep_throwsSessionNotFound` | Wyjątek dla nieistniejącej sesji |
| `executeNextStep_throwsWhenCompleted` | Wyjątek gdy sesja jest COMPLETED |
| `processStep_success` | Przetwarza krok z payloadem i zwraca sukces |
| `getStatus_throwsNotFound` | Wyjątek dla nieistniejącej sesji |
| `getStatus_returnsCorrectStatus` | Zwraca poprawny status z historią kroków |
| `rewindToStep_rewinds` | Cofa sesję do podanego kroku |

**Łącznie: 12 testów ✅**

---

### 2. `MainServiceClientTest.java`

**Ścieżka:** [MainServiceClientTest.java](file:///c:/Users/lukas_1b707ym/Documents/Studia/Semestr_6/CookMate/simulator-service/src/test/java/com/cookmate/simulator/client/MainServiceClientTest.java)

Testy Feign client'a z `@Mock` (MainServiceClient to interfejs Feign, nie RestTemplate — dostosowano podejście).

| Test | Opis |
|---|---|
| `getRecipeSteps_returnsStepsOnSuccess` | Sukces — zwraca listę kroków |
| `getRecipeSteps_returnsEmptyList` | Sukces — pusta lista gdy brak kroków |
| `getRecipeSteps_throwsNotFoundOn404` | `FeignException.NotFound` przy 404 |
| `getRecipeSteps_throwsOnServerError` | `FeignException.InternalServerError` przy 500 |
| `getRecipeSteps_throwsOnNetworkError` | `RuntimeException` przy błędzie sieci |
| `notifyStepCompleted_sendsCorrectData` | Wysyła POST z poprawnymi danymi |
| `notifyStepCompleted_throwsOnServerError` | Wyjątek przy błędzie serwera |

**Łącznie: 7 testów ✅**

---

### 3. `SimulationControllerIntegrationTest.java`

**Ścieżka:** [SimulationControllerIntegrationTest.java](file:///c:/Users/lukas_1b707ym/Documents/Studia/Semestr_6/CookMate/simulator-service/src/test/java/com/cookmate/simulator/controller/SimulationControllerIntegrationTest.java)

Integration testy z `@SpringBootTest` + `@AutoConfigureMockMvc` + H2 + `@MockitoBean MainServiceClient`.

| Test | Endpoint | Oczekiwany wynik |
|---|---|---|
| `startSimulation_returns201` | `POST /api/simulator/sessions/start` | 201 Created, status RUNNING |
| `startSimulation_returns400WhenNoRecipeId` | `POST /api/simulator/sessions/start` | 400 Bad Request |
| `startSimulation_returns503WhenMainDown` | `POST /api/simulator/sessions/start` | 503 Service Unavailable |
| `executeNextStep_returns200` | `POST /sessions/{id}/steps/execute` | 200 OK, success=true |
| `executeNextStep_returns404` | `POST /sessions/{id}/steps/execute` | 404 Not Found |
| `receiveStep_returns200` | `POST /sessions/{id}/step` | 200 OK, success=true |
| `receiveStep_returns400OnInvalidPayload` | `POST /sessions/{id}/step` | 400 Bad Request |
| `getStatus_returns200` | `GET /sessions/{id}/status` | 200 OK, status RUNNING |
| `getStatus_returns404` | `GET /sessions/{id}/status` | 404 Not Found |
| `getHistory_returns200` | `GET /sessions/{id}/history` | 200 OK, lista kroków |
| `rewind_returns200` | `POST /sessions/{id}/rewind` | 200 OK, cofnięta sesja |

**Łącznie: 11 testów ✅**

---

### 4. `GuidedCookingFlowTest.java`

**Ścieżka:** [GuidedCookingFlowTest.java](file:///c:/Users/lukas_1b707ym/Documents/Studia/Semestr_6/CookMate/simulator-service/src/test/java/com/cookmate/simulator/integration/GuidedCookingFlowTest.java)

Testy end-to-end symulujące pełny cykl życia sesji gotowania.

| Test | Opis |
|---|---|
| `fullGuidedCookingFlow` | start → status (2× PENDING) → execute step 1 → status (1× EXECUTED, 1× PENDING) → execute step 2 → status COMPLETED → history (2× EXECUTED) |
| `flowWithRewind` | start → execute 1 → execute 2 → COMPLETED → rewind do 1 → RUNNING → re-execute 2 → COMPLETED |
| `flowWithProcessStep` | start → processStep(1) → processStep(2) → COMPLETED |
| `errorFlow_sessionNotFound` | execute/status/history na nieistniejącej sesji → 404 |

**Łącznie: 4 testy ✅**

---

## 🔧 Zmiany infrastrukturalne

### `pom.xml`

```diff
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webmvc-test</artifactId>
+            <scope>test</scope>
+        </dependency>
```

> **Powód:** H2 potrzebne do in-memory DB w testach integracyjnych. `spring-boot-starter-webmvc-test` wymagane w Spring Boot 4.x — `AutoConfigureMockMvc` przeniesione z `org.springframework.boot.test.autoconfigure.web.servlet` do `org.springframework.boot.webmvc.test.autoconfigure`.

### `application-test.yml`

```diff
-    url: jdbc:h2:mem:testdb
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL
+  cloud:
+    discovery:
+      enabled: false
+    config:
+      enabled: false
+eureka:
+  client:
+    enabled: false
```

> **Powód:** `MODE=PostgreSQL` rozwiązuje problem z `PESSIMISTIC_WRITE` lock (`FOR NO KEY UPDATE`) — H2 nie obsługuje tej składni PostgreSQL bez tego trybu. Wyłączenie Eureka/Cloud Config zapobiega próbom łączenia się z zewnętrznymi serwisami w testach.

---

## 📊 Wyniki testów

```
Tests run: 40, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

| Klasa testowa | Testy | Wynik |
|---|---|---|
| `SimulationSessionServiceTest` | 12 | ✅ PASS |
| `MainServiceClientTest` | 7 | ✅ PASS |
| `SimulationControllerIntegrationTest` | 11 | ✅ PASS |
| `GuidedCookingFlowTest` | 4 | ✅ PASS |
| `SimulationServiceTest` (istniejący) | 6 | ✅ PASS |

---

## ✅ Testy akceptacyjne

- [x] Service tests przechodzą
- [x] Controller tests przechodzą
- [x] MainServiceClient tests przechodzą
- [x] End-to-end flow tests przechodzą
- [x] Error scenarios testowane
- [x] Integration między serwisami działa

---

## 📝 Uwagi

- **`endSimulation`** — serwis nie posiada osobnej metody `endSimulation`. Sesja automatycznie zmienia status na `COMPLETED` po wykonaniu ostatniego kroku. Testy weryfikują ten mechanizm.
- **Feign vs RestTemplate** — Issue sugerowało `@RestClientTest` / `MockRestServiceServer`, ale `MainServiceClient` to interfejs Feign. Zastosowano `@Mock` co jest poprawnym podejściem dla Feign clients.
- **Spring Boot 4.x** — `AutoConfigureMockMvc` przeniesione do osobnego modułu `spring-boot-webmvc-test`. Import: `org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc`.
