### PR TITLE
Add extensive Step unit and validation tests

### DIFF
--- a/main-service/src/test/java/com/cookmate/main/mapper/StepMapperTest.java
+++ b/main-service/src/test/java/com/cookmate/main/mapper/StepMapperTest.java
@@ -3,6 +3,7 @@ package com.cookmate.main.mapper;
 import com.cookmate.main.dto.StepDTO;
 import com.cookmate.main.model.ActionType;
 import com.cookmate.main.model.Step;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -16,18 +17,22 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @ActiveProfiles("test")
+@DisplayName("StepMapper")
 class StepMapperTest {
 
     @Autowired
     private StepMapper stepMapper;
 
+    // --- toDTO ---
+
     @Test
+    @DisplayName("toDTO — mapuje wszystkie pola entity → DTO")
     void shouldMapStepToDTO() {
         // given
         LocalDateTime now = LocalDateTime.now();
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("size", "small");
-        
+
         Step entity = Step.builder()
                 .id(1L)
                 .stepNumber(1)
@@ -56,11 +61,38 @@ class StepMapperTest {
     }
 
     @Test
+    @DisplayName("toDTO — obsługuje opcjonalne pola jako null")
+    void toDTO_handlesNullOptionalFields() {
+        // given
+        Step entity = Step.builder()
+                .id(2L)
+                .stepNumber(1)
+                .description("Prosty krok")
+                .action(ActionType.WAIT)
+                .recipeId("recipe-simple")
+                .parameters(null)
+                .durationMinutes(null)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        // when
+        StepDTO dto = stepMapper.toDTO(entity);
+
+        // then
+        assertNotNull(dto);
+        assertNull(dto.parameters());
+        assertNull(dto.durationMinutes());
+    }
+
+    // --- toEntity ---
+
+    @Test
+    @DisplayName("toEntity — mapuje DTO → entity (bez createdAt)")
     void shouldMapDTOToEntity() {
         // given
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("temp", 180);
-        
+
         StepDTO dto = StepDTO.builder()
                 .stepNumber(2)
                 .description("Smażenie na patelni")
@@ -87,7 +119,10 @@ class StepMapperTest {
         assertNull(entity.getCreatedAt());
     }
 
+    // --- null handling ---
+
     @Test
+    @DisplayName("toDTO/toEntity — null input zwraca null")
     void shouldReturnNullWhenSourceIsNull() {
         // when
         StepDTO dto = stepMapper.toDTO(null);
@@ -96,5 +131,87 @@ class StepMapperTest {
         // then
         assertNull(dto);
         assertNull(entity);
+    }
+
+    // --- bidirectional mapping ---
+
+    @Test
+    @DisplayName("bidirectional — entity → DTO → entity zachowuje wartości")
+    void bidirectionalMapping_entityToDtoToEntity() {
+        // given
+        Map<String, Object> params = new HashMap<>();
+        params.put("temperature", 200);
+        params.put("unit", "°C");
+
+        Step original = Step.builder()
+                .id(10L)
+                .stepNumber(3)
+                .description("Piecz ciasto")
+                .action(ActionType.BAKE)
+                .recipeId("recipe-bake")
+                .durationMinutes(45)
+                .parameters(params)
+                .createdAt(LocalDateTime.of(2026, 5, 19, 12, 0))
+                .build();
+
+        // when
+        StepDTO dto = stepMapper.toDTO(original);
+        Step reconstructed = stepMapper.toEntity(dto);
+
+        // then — pola mapowane powinny być identyczne
+        assertEquals(original.getStepNumber(), reconstructed.getStepNumber());
+        assertEquals(original.getDescription(), reconstructed.getDescription());
+        assertEquals(original.getAction(), reconstructed.getAction());
+        assertEquals(original.getRecipeId(), reconstructed.getRecipeId());
+        assertEquals(original.getDurationMinutes(), reconstructed.getDurationMinutes());
+        assertEquals(original.getParameters(), reconstructed.getParameters());
+
+        // createdAt jest ignorowane przy toEntity (@Mapping target="createdAt",
+        // ignore=true)
+        assertNull(reconstructed.getCreatedAt());
+        // id nie jest kopiowane przy toEntity (brak mappingu)
+        assertEquals(original.getId(), dto.id()); // DTO ma id
+    }
+
+    @Test
+    @DisplayName("bidirectional — DTO → entity → DTO zachowuje wartości")
+    void bidirectionalMapping_dtoToEntityToDto() {
+        // given
+        StepDTO original = StepDTO.builder()
+                .stepNumber(5)
+                .description("Grilluj mięso")
+                .action(ActionType.GRILL)
+                .recipeId("recipe-grill")
+                .durationMinutes(30)
+                .parameters(Map.of("heat", "high"))
+                .build();
+
+        // when
+        Step entity = stepMapper.toEntity(original);
+        StepDTO reconstructed = stepMapper.toDTO(entity);
+
+        // then
+        assertEquals(original.stepNumber(), reconstructed.stepNumber());
+        assertEquals(original.description(), reconstructed.description());
+        assertEquals(original.action(), reconstructed.action());
+        assertEquals(original.recipeId(), reconstructed.recipeId());
+        assertEquals(original.durationMinutes(), reconstructed.durationMinutes());
+        assertEquals(original.parameters(), reconstructed.parameters());
+    }
+
+    // --- all ActionTypes ---
+
+    @Test
+    @DisplayName("toDTO — poprawnie mapuje każdy ActionType")
+    void toDTO_mapsAllActionTypes() {
+        for (ActionType action : ActionType.values()) {
+            Step entity = Step.builder()
+                    .stepNumber(1).description("test").action(action).recipeId("r-1").build();
+
+            StepDTO dto = stepMapper.toDTO(entity);
+
+            assertNotNull(dto);
+            assertEquals(action, dto.action(), "ActionType " + action + " powinien być poprawnie mapowany");
+        }
     }
 }

--- a/main-service/src/test/java/com/cookmate/main/model/StepTest.java
+++ b/main-service/src/test/java/com/cookmate/main/model/StepTest.java
@@ -1,0 +1,345 @@
+package com.cookmate.main.model;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Testy jednostkowe dla Step entity — weryfikacja builder pattern,
+ * getterów/setterów, equals/hashCode, toString i obsługi null.
+ */
+@DisplayName("Step Entity")
+class StepTest {
+
+    // --- Builder pattern ---
+
+    @Nested
+    @DisplayName("Builder pattern")
+    class BuilderTests {
+
+        @Test
+        @DisplayName("tworzy Step z wszystkimi polami")
+        void builderCreatesStepWithAllFields() {
+            LocalDateTime now = LocalDateTime.now();
+            Map<String, Object> params = Map.of("temp", 180, "unit", "°C");
+
+            Step step = Step.builder()
+                    .id(1L)
+                    .stepNumber(1)
+                    .description("Pokrój cebulę")
+                    .mainIngredient("cebula")
+                    .action(ActionType.CUT)
+                    .parameters(params)
+                    .durationMinutes(10)
+                    .recipeId("recipe-123")
+                    .createdAt(now)
+                    .updatedAt(now)
+                    .build();
+
+            assertEquals(1L, step.getId());
+            assertEquals(1, step.getStepNumber());
+            assertEquals("Pokrój cebulę", step.getDescription());
+            assertEquals("cebula", step.getMainIngredient());
+            assertEquals(ActionType.CUT, step.getAction());
+            assertEquals(params, step.getParameters());
+            assertEquals(10, step.getDurationMinutes());
+            assertEquals("recipe-123", step.getRecipeId());
+            assertEquals(now, step.getCreatedAt());
+            assertEquals(now, step.getUpdatedAt());
+        }
+
+        @Test
+        @DisplayName("tworzy Step z wymaganymi polami (bez optional)")
+        void builderCreatesStepWithRequiredFieldsOnly() {
+            Step step = Step.builder()
+                    .stepNumber(1)
+                    .description("Odważ mąkę")
+                    .action(ActionType.WEIGH)
+                    .recipeId("recipe-456")
+                    .build();
+
+            assertNull(step.getId());
+            assertEquals(1, step.getStepNumber());
+            assertEquals("Odważ mąkę", step.getDescription());
+            assertEquals(ActionType.WEIGH, step.getAction());
+            assertEquals("recipe-456", step.getRecipeId());
+            assertNull(step.getMainIngredient());
+            assertNull(step.getParameters());
+            assertNull(step.getDurationMinutes());
+            assertNull(step.getCreatedAt());
+            assertNull(step.getUpdatedAt());
+        }
+    }
+
+    // --- Gettery i settery ---
+
+    @Nested
+    @DisplayName("Gettery i settery")
+    class GettersSettersTests {
+
+        @Test
+        @DisplayName("settery ustawiają wartości poprawnie")
+        void settersWork() {
+            Step step = new Step();
+            LocalDateTime now = LocalDateTime.now();
+
+            step.setId(42L);
+            step.setStepNumber(3);
+            step.setDescription("Podsmaż na oleju");
+            step.setMainIngredient("olej");
+            step.setAction(ActionType.FRYING_PAN);
+            step.setParameters(Map.of("oil", "olive"));
+            step.setDurationMinutes(15);
+            step.setRecipeId("recipe-789");
+            step.setCreatedAt(now);
+            step.setUpdatedAt(now);
+
+            assertEquals(42L, step.getId());
+            assertEquals(3, step.getStepNumber());
+            assertEquals("Podsmaż na oleju", step.getDescription());
+            assertEquals("olej", step.getMainIngredient());
+            assertEquals(ActionType.FRYING_PAN, step.getAction());
+            assertEquals(Map.of("oil", "olive"), step.getParameters());
+            assertEquals(15, step.getDurationMinutes());
+            assertEquals("recipe-789", step.getRecipeId());
+            assertEquals(now, step.getCreatedAt());
+            assertEquals(now, step.getUpdatedAt());
+        }
+
+        @Test
+        @DisplayName("settery akceptują null dla opcjonalnych pól")
+        void settersAcceptNullForOptionalFields() {
+            Step step = Step.builder()
+                    .stepNumber(1)
+                    .description("Test")
+                    .action(ActionType.WAIT)
+                    .recipeId("r-1")
+                    .durationMinutes(10)
+                    .mainIngredient("cebula")
+                    .parameters(Map.of("key", "val"))
+                    .build();
+
+            step.setDurationMinutes(null);
+            step.setMainIngredient(null);
+            step.setParameters(null);
+
+            assertNull(step.getDurationMinutes());
+            assertNull(step.getMainIngredient());
+            assertNull(step.getParameters());
+        }
+    }
+
+    // --- Null handling ---
+
+    @Nested
+    @DisplayName("Null handling")
+    class NullHandlingTests {
+
+        @Test
+        @DisplayName("no-arg constructor tworzy Step z nullami")
+        void noArgConstructorCreatesStepWithNulls() {
+            Step step = new Step();
+
+            assertNull(step.getId());
+            assertNull(step.getDescription());
+            assertNull(step.getMainIngredient());
+            assertNull(step.getAction());
+            assertNull(step.getParameters());
+            assertNull(step.getDurationMinutes());
+            assertNull(step.getRecipeId());
+            assertNull(step.getCreatedAt());
+            assertNull(step.getUpdatedAt());
+            // stepNumber to Integer (boxed) — domyślnie null
+            assertNull(step.getStepNumber());
+        }
+
+        @Test
+        @DisplayName("builder akceptuje null wartości")
+        void builderAcceptsNullValues() {
+            Step step = Step.builder()
+                    .id(null)
+                    .description(null)
+                    .action(null)
+                    .parameters(null)
+                    .durationMinutes(null)
+                    .recipeId(null)
+                    .build();
+
+            assertNull(step.getId());
+            assertNull(step.getDescription());
+            assertNull(step.getAction());
+            assertNull(step.getParameters());
+            assertNull(step.getDurationMinutes());
+            assertNull(step.getRecipeId());
+        }
+    }
+
+    // --- equals / hashCode ---
+
+    @Nested
+    @DisplayName("equals i hashCode")
+    class EqualsHashCodeTests {
+
+        @Test
+        @DisplayName("dwa identyczne Step są equal")
+        void identicalStepsAreEqual() {
+            LocalDateTime now = LocalDateTime.now();
+            Step step1 = Step.builder().id(1L).stepNumber(1).description("A").action(ActionType.CUT)
+                    .recipeId("r-1").createdAt(now).build();
+            Step step2 = Step.builder().id(1L).stepNumber(1).description("A").action(ActionType.CUT)
+                    .recipeId("r-1").createdAt(now).build();
+
+            assertEquals(step1, step2);
+            assertEquals(step1.hashCode(), step2.hashCode());
+        }
+
+        @Test
+        @DisplayName("Step nie jest equal do null")
+        void stepNotEqualToNull() {
+            Step step = Step.builder().id(1L).stepNumber(1).description("A")
+                    .action(ActionType.CUT).recipeId("r-1").build();
+
+            assertNotEquals(null, step);
+        }
+
+        @Test
+        @DisplayName("różne Step nie są equal")
+        void differentStepsAreNotEqual() {
+            Step step1 = Step.builder().id(1L).stepNumber(1).description("A")
+                    .action(ActionType.CUT).recipeId("r-1").build();
+            Step step2 = Step.builder().id(2L).stepNumber(2).description("B")
+                    .action(ActionType.MIX).recipeId("r-2").build();
+
+            assertNotEquals(step1, step2);
+        }
+
+        @Test
+        @DisplayName("Step jest equal do samego siebie")
+        void stepEqualsItself() {
+            Step step = Step.builder().id(1L).stepNumber(1).description("A")
+                    .action(ActionType.CUT).recipeId("r-1").build();
+
+            assertEquals(step, step);
+        }
+    }
+
+    // --- toString ---
+
+    @Nested
+    @DisplayName("toString")
+    class ToStringTests {
+
+        @Test
+        @DisplayName("toString generuje content z kluczowymi polami")
+        void toStringContainsKeyFields() {
+            Step step = Step.builder()
+                    .id(5L)
+                    .stepNumber(3)
+                    .description("Gotuj w garnku")
+                    .action(ActionType.POT)
+                    .recipeId("recipe-abc")
+                    .durationMinutes(20)
+                    .build();
+
+            String result = step.toString();
+
+            assertNotNull(result);
+            assertFalse(result.isEmpty());
+            assertTrue(result.contains("5"), "toString powinien zawierać id");
+            assertTrue(result.contains("3"), "toString powinien zawierać stepNumber");
+            assertTrue(result.contains("Gotuj w garnku"), "toString powinien zawierać description");
+            assertTrue(result.contains("POT"), "toString powinien zawierać action");
+            assertTrue(result.contains("recipe-abc"), "toString powinien zawierać recipeId");
+        }
+    }
+
+    // --- Optional fields ---
+
+    @Nested
+    @DisplayName("Optional fields (parameters, durationMinutes, mainIngredient)")
+    class OptionalFieldsTests {
+
+        @Test
+        @DisplayName("parameters mogą być pustą mapą")
+        void parametersCanBeEmptyMap() {
+            Step step = Step.builder()
+                    .stepNumber(1).description("A").action(ActionType.WAIT)
+                    .recipeId("r-1").parameters(Map.of()).build();
+
+            assertNotNull(step.getParameters());
+            assertTrue(step.getParameters().isEmpty());
+        }
+
+        @Test
+        @DisplayName("parameters mogą zawierać złożone wartości")
+        void parametersCanContainComplexValues() {
+            Map<String, Object> params = Map.of(
+                    "temperature", 200,
+                    "unit", "°C",
+                    "preheated", true);
+
+            Step step = Step.builder()
+                    .stepNumber(1).description("Piecz").action(ActionType.BAKE)
+                    .recipeId("r-1").parameters(params).build();
+
+            assertEquals(200, step.getParameters().get("temperature"));
+            assertEquals("°C", step.getParameters().get("unit"));
+            assertEquals(true, step.getParameters().get("preheated"));
+        }
+
+        @Test
+        @DisplayName("durationMinutes akceptuje zero")
+        void durationAcceptsZero() {
+            Step step = Step.builder()
+                    .stepNumber(1).description("Natychmiastowe").action(ActionType.POUR)
+                    .recipeId("r-1").durationMinutes(0).build();
+
+            assertEquals(0, step.getDurationMinutes());
+        }
+
+        @Test
+        @DisplayName("mainIngredient jest opcjonalny")
+        void mainIngredientIsOptional() {
+            Step withIngredient = Step.builder()
+                    .stepNumber(1).description("A").action(ActionType.CUT)
+                    .recipeId("r-1").mainIngredient("pomidor").build();
+            Step withoutIngredient = Step.builder()
+                    .stepNumber(1).description("A").action(ActionType.CUT)
+                    .recipeId("r-1").build();
+
+            assertEquals("pomidor", withIngredient.getMainIngredient());
+            assertNull(withoutIngredient.getMainIngredient());
+        }
+    }
+
+    // --- ActionType ---
+
+    @Nested
+    @DisplayName("ActionType enum")
+    class ActionTypeTests {
+
+        @Test
+        @DisplayName("wszystkie ActionType mają displayName")
+        void allActionTypesHaveDisplayName() {
+            for (ActionType type : ActionType.values()) {
+                assertNotNull(type.getDisplayName(), type.name() + " powinien mieć displayName");
+                assertFalse(type.getDisplayName().isBlank(), type.name() + " displayName nie powinien być pusty");
+            }
+        }
+
+        @Test
+        @DisplayName("Step akceptuje każdy ActionType")
+        void stepAcceptsAllActionTypes() {
+            for (ActionType type : ActionType.values()) {
+                Step step = Step.builder()
+                        .stepNumber(1).description("test").action(type).recipeId("r-1").build();
+                assertEquals(type, step.getAction());
+            }
+        }
+    }
+}

--- a/main-service/src/test/java/com/cookmate/main/model/StepValidationTest.java
+++ b/main-service/src/test/java/com/cookmate/main/model/StepValidationTest.java
@@ -1,0 +1,325 @@
+package com.cookmate.main.model;
+
+import com.cookmate.main.dto.StepDTO;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Testy Bean Validation dla StepDTO — weryfikacja @NotBlank, @NotNull,
+ * @Positive, @PositiveOrZero na polach DTO.
+ */
+@DisplayName("StepDTO — Bean Validation")
+class StepValidationTest {
+
+    private static Validator validator;
+
+    @BeforeAll
+    static void setUpValidator() {
+        try (ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+            validator = factory.getValidator();
+        }
+    }
+
+    // --- Valid DTO ---
+
+    @Nested
+    @DisplayName("Poprawne dane")
+    class ValidDataTests {
+
+        @Test
+        @DisplayName("poprawny StepDTO nie generuje violation")
+        void validStepDTO_noViolations() {
+            StepDTO dto = StepDTO.builder()
+                    .stepNumber(1)
+                    .description("Pokrój cebulę")
+                    .action(ActionType.CUT)
+                    .recipeId("recipe-123")
+                    .durationMinutes(10)
+                    .parameters(Map.of("size", "small"))
+                    .build();
+
+            Set<ConstraintViolation<StepDTO>> violations = validator.validate(dto);
+
+            assertThat(violations).isEmpty();
+        }
+
+        @Test
+        @DisplayName("poprawny StepDTO z minimalnymi polami")
+        void validStepDTO_minimalFields() {
+            StepDTO dto = StepDTO.builder()
+                    .stepNumber(1)
+                    .description("Krok")
+                    .action(ActionType.WAIT)
+                    .recipeId("r-1")
+                    .build();
+
+            Set<ConstraintViolation<StepDTO>> violations = validator.validate(dto);
+
+            assertThat(violations).isEmpty();
+        }
+
+        @Test
+        @DisplayName("durationMinutes = 0 jest akceptowalne (@PositiveOrZero)")
+        void zeroDuration_isValid() {
+            StepDTO dto = StepDTO.builder()
+                    .stepNumber(1)
+                    .description("Natychmiastowy krok")
+                    .action(ActionType.POUR)
+                    .recipeId("r-1")
+                    .durationMinutes(0)
+                    .build();
+
+            Set<ConstraintViolation<StepDTO>> violations = validator.validate(dto);
+
+            assertThat(violations).isEmpty();
+        }
+    }
+
+    // --- stepNumber validation ---
+
+    @Nested
+    @DisplayName("stepNumber validation")
+    class StepNumberValidation {
+
+        @Test
+        @DisplayName("null stepNumber → violation @NotNull")
+        void nullStepNumber_violation() {
+            StepDTO dto = StepDTO.builder()
+                    .stepNumber(null)
+                    .description("Krok")
+                    .action(ActionType.CUT)
+                    .recipeId("r-1")
+                    .build();
+
+            Set<ConstraintViolation<StepDTO>> violations = validator.validate(dto);
+
+            assertThat(violations).isNotEmpty();
+            assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("stepNumber"));
+        }
+
+        @Test
+        @DisplayName("stepNumber = 0 → violation @Positive")
+        void zeroStepNumber_violation() {
+            StepDTO dto = StepDTO.builder()
+                    .stepNumber(0)
+                    .description("Krok")
+                    .action(ActionType.CUT)
+                    .recipeId("r-1")
+                    .build();
+
+            Set<ConstraintViolation<StepDTO>> violations = validator.validate(dto);
+
+            assertThat(violations).isNotEmpty();
+            assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("stepNumber"));
+        }
+
+        @Test
+        @DisplayName("stepNumber = -1 → violation @Positive")
+        void negativeStepNumber_violation() {
+            StepDTO dto = StepDTO.builder()
+                    .stepNumber(-1)
+                    .description("Krok")
+                    .action(ActionType.CUT)
+                    .recipeId("r-1")
+                    .build();
+
+            Set<ConstraintViolation<StepDTO>> violations = validator.validate(dto);
+
+            assertThat(violations).isNotEmpty();
+            assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("stepNumber"));
+        }
+    }
+
+    // --- description validation ---
+
+    @Nested
+    @DisplayName("description validation")
+    class DescriptionValidation {
+
+        @Test
+        @DisplayName("null description → violation @NotBlank")
+        void nullDescription_violation() {
+            StepDTO dto = StepDTO.builder()
+                    .stepNumber(1)
+                    .description(null)
+                    .action(ActionType.CUT)
+                    .recipeId("r-1")
+                    .build();
+
+            Set<ConstraintViolation<StepDTO>> violations = validator.validate(dto);
+
+            assertThat(violations).isNotEmpty();
+            assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("description"));
+        }
+
+        @Test
+        @DisplayName("pusty description → violation @NotBlank")
+        void emptyDescription_violation() {
+            StepDTO dto = StepDTO.builder()
+                    .stepNumber(1)
+                    .description("")
+                    .action(ActionType.CUT)
+                    .recipeId("r-1")
+                    .build();
+
+            Set<ConstraintViolation<StepDTO>> violations = validator.validate(dto);
+
+            assertThat(violations).isNotEmpty();
+            assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("description"));
+        }
+
+        @Test
+        @DisplayName("biały description (spacje) → violation @NotBlank")
+        void blankDescription_violation() {
+            StepDTO dto = StepDTO.builder()
+                    .stepNumber(1)
+                    .description("   ")
+                    .action(ActionType.CUT)
+                    .recipeId("r-1")
+                    .build();
+
+            Set<ConstraintViolation<StepDTO>> violations = validator.validate(dto);
+
+            assertThat(violations).isNotEmpty();
+            assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("description"));
+        }
+    }
+
+    // --- action validation ---
+
+    @Nested
+    @DisplayName("action validation")
+    class ActionValidation {
+
+        @Test
+        @DisplayName("null action → violation @NotNull")
+        void nullAction_violation() {
+            StepDTO dto = StepDTO.builder()
+                    .stepNumber(1)
+                    .description("Krok")
+                    .action(null)
+                    .recipeId("r-1")
+                    .build();
+
+            Set<ConstraintViolation<StepDTO>> violations = validator.validate(dto);
+
+            assertThat(violations).isNotEmpty();
+            assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("action"));
+        }
+    }
+
+    // --- recipeId validation ---
+
+    @Nested
+    @DisplayName("recipeId validation")
+    class RecipeIdValidation {
+
+        @Test
+        @DisplayName("null recipeId → violation @NotBlank")
+        void nullRecipeId_violation() {
+            StepDTO dto = StepDTO.builder()
+                    .stepNumber(1)
+                    .description("Krok")
+                    .action(ActionType.CUT)
+                    .recipeId(null)
+                    .build();
+
+            Set<ConstraintViolation<StepDTO>> violations = validator.validate(dto);
+
+            assertThat(violations).isNotEmpty();
+            assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("recipeId"));
+        }
+
+        @Test
+        @DisplayName("pusty recipeId → violation @NotBlank")
+        void emptyRecipeId_violation() {
+            StepDTO dto = StepDTO.builder()
+                    .stepNumber(1)
+                    .description("Krok")
+                    .action(ActionType.CUT)
+                    .recipeId("")
+                    .build();
+
+            Set<ConstraintViolation<StepDTO>> violations = validator.validate(dto);
+
+            assertThat(violations).isNotEmpty();
+            assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("recipeId"));
+        }
+    }
+
+    // --- durationMinutes validation ---
+
+    @Nested
+    @DisplayName("durationMinutes validation")
+    class DurationValidation {
+
+        @Test
+        @DisplayName("null durationMinutes jest akceptowalne (opcjonalne)")
+        void nullDuration_noViolation() {
+            StepDTO dto = StepDTO.builder()
+                    .stepNumber(1)
+                    .description("Krok")
+                    .action(ActionType.WAIT)
+                    .recipeId("r-1")
+                    .durationMinutes(null)
+                    .build();
+
+            Set<ConstraintViolation<StepDTO>> violations = validator.validate(dto);
+
+            assertThat(violations).isEmpty();
+        }
+
+        @Test
+        @DisplayName("durationMinutes = -1 → violation @PositiveOrZero")
+        void negativeDuration_violation() {
+            StepDTO dto = StepDTO.builder()
+                    .stepNumber(1)
+                    .description("Krok")
+                    .action(ActionType.WAIT)
+                    .recipeId("r-1")
+                    .durationMinutes(-1)
+                    .build();
+
+            Set<ConstraintViolation<StepDTO>> violations = validator.validate(dto);
+
+            assertThat(violations).isNotEmpty();
+            assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("durationMinutes"));
+        }
+    }
+
+    // --- multiple violations ---
+
+    @Nested
+    @DisplayName("Multiple violations")
+    class MultipleViolations {
+
+        @Test
+        @DisplayName("wiele niepoprawnych pól → wiele violations")
+        void multipleInvalidFields_multipleViolations() {
+            StepDTO dto = StepDTO.builder()
+                    .stepNumber(null)
+                    .description(null)
+                    .action(null)
+                    .recipeId(null)
+                    .durationMinutes(-5)
+                    .build();
+
+            Set<ConstraintViolation<StepDTO>> violations = validator.validate(dto);
+
+            // stepNumber(NotNull), description(NotBlank), action(NotNull),
+            // recipeId(NotBlank), durationMinutes(PositiveOrZero)
+            assertThat(violations).hasSizeGreaterThanOrEqualTo(5);
+        }
+    }
+}

--- a/main-service/src/test/java/com/cookmate/main/repository/StepRepositoryTest.java
+++ b/main-service/src/test/java/com/cookmate/main/repository/StepRepositoryTest.java
@@ -2,26 +2,89 @@ package com.cookmate.main.repository;
 
 import com.cookmate.main.model.ActionType;
 import com.cookmate.main.model.Step;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @Transactional
 @ActiveProfiles("test")
+@DisplayName("StepRepository")
 class StepRepositoryTest {
 
     @Autowired
     private StepRepository stepRepository;
 
+    // --- save i findById ---
+
     @Test
+    @DisplayName("save — zapisuje Step i generuje ID")
+    void save_persistsStepAndGeneratesId() {
+        // given
+        Step step = Step.builder()
+                .recipeId("recipe-save-1")
+                .stepNumber(1)
+                .description("Odważ składniki")
+                .action(ActionType.WEIGH)
+                .durationMinutes(5)
+                .mainIngredient("mąka")
+                .parameters(Map.of("weight", "500g"))
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        // when
+        Step saved = stepRepository.save(step);
+
+        // then
+        assertThat(saved.getId()).isNotNull();
+        assertThat(saved.getDescription()).isEqualTo("Odważ składniki");
+        assertThat(saved.getAction()).isEqualTo(ActionType.WEIGH);
+        assertThat(saved.getDurationMinutes()).isEqualTo(5);
+        assertThat(saved.getMainIngredient()).isEqualTo("mąka");
+    }
+
+    @Test
+    @DisplayName("findById — zwraca zapisany Step")
+    void findById_returnsSavedStep() {
+        // given
+        Step saved = stepRepository.save(Step.builder()
+                .recipeId("recipe-find-1")
+                .stepNumber(1)
+                .description("Pokrój warzywa")
+                .action(ActionType.CUT)
+                .createdAt(LocalDateTime.now())
+                .build());
+
+        // when
+        Optional<Step> found = stepRepository.findById(saved.getId());
+
+        // then
+        assertThat(found).isPresent();
+        assertThat(found.get().getDescription()).isEqualTo("Pokrój warzywa");
+        assertThat(found.get().getRecipeId()).isEqualTo("recipe-find-1");
+    }
+
+    @Test
+    @DisplayName("findById — zwraca empty dla nieistniejącego ID")
+    void findById_returnsEmptyForNonExistentId() {
+        Optional<Step> result = stepRepository.findById(99999L);
+        assertThat(result).isEmpty();
+    }
+
+    // --- findByRecipeIdOrderByStepNumberAsc ---
+
+    @Test
+    @DisplayName("findByRecipeIdOrderByStepNumberAsc — sortuje po stepNumber")
     void shouldFindStepsByRecipeIdSortedByStepNumber() {
         // given
         String recipeId = "recipe-abc-123";
@@ -56,6 +119,29 @@ class StepRepositoryTest {
     }
 
     @Test
+    @DisplayName("findByRecipeIdOrderByStepNumberAsc — nie miesza przepisów")
+    void findByRecipeId_doesNotMixRecipes() {
+        // given
+        stepRepository.save(Step.builder().recipeId("r-A").stepNumber(1)
+                .description("Krok A").action(ActionType.CUT).createdAt(LocalDateTime.now()).build());
+        stepRepository.save(Step.builder().recipeId("r-B").stepNumber(1)
+                .description("Krok B").action(ActionType.MIX).createdAt(LocalDateTime.now()).build());
+
+        // when
+        List<Step> resultsA = stepRepository.findByRecipeIdOrderByStepNumberAsc("r-A");
+        List<Step> resultsB = stepRepository.findByRecipeIdOrderByStepNumberAsc("r-B");
+
+        // then
+        assertThat(resultsA).hasSize(1);
+        assertThat(resultsA.get(0).getDescription()).isEqualTo("Krok A");
+        assertThat(resultsB).hasSize(1);
+        assertThat(resultsB.get(0).getDescription()).isEqualTo("Krok B");
+    }
+
+    // --- findByIdAndRecipeId ---
+
+    @Test
+    @DisplayName("findByIdAndRecipeId — zwraca krok gdy ID i recipeId pasują")
     void shouldFindByIdAndRecipeId() {
         // given
         String recipeId = "recipe-xyz";
@@ -73,5 +159,110 @@ class StepRepositoryTest {
         // then
         assertThat(result).isPresent();
         assertThat(result.get().getAction()).isEqualTo(ActionType.WAIT);
+    }
+
+    @Test
+    @DisplayName("findByIdAndRecipeId — zwraca empty gdy recipeId nie pasuje")
+    void findByIdAndRecipeId_returnsEmptyWhenRecipeIdMismatch() {
+        // given
+        Step saved = stepRepository.save(Step.builder()
+                .recipeId("recipe-correct")
+                .stepNumber(1)
+                .description("Krok")
+                .action(ActionType.STIR)
+                .createdAt(LocalDateTime.now())
+                .build());
+
+        // when
+        var result = stepRepository.findByIdAndRecipeId(saved.getId(), "recipe-wrong");
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    // --- delete ---
+
+    @Test
+    @DisplayName("delete — usuwa Step z bazy")
+    void delete_removesStep() {
+        // given
+        Step saved = stepRepository.save(Step.builder()
+                .recipeId("recipe-del")
+                .stepNumber(1)
+                .description("Do usunięcia")
+                .action(ActionType.WAIT)
+                .createdAt(LocalDateTime.now())
+                .build());
+        Long id = saved.getId();
+
+        // when
+        stepRepository.delete(saved);
+        stepRepository.flush();
+
+        // then
+        assertThat(stepRepository.findById(id)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("deleteById — usuwa Step po ID")
+    void deleteById_removesStep() {
+        // given
+        Step saved = stepRepository.save(Step.builder()
+                .recipeId("recipe-del2")
+                .stepNumber(1)
+                .description("Delete by ID")
+                .action(ActionType.POUR)
+                .createdAt(LocalDateTime.now())
+                .build());
+        Long id = saved.getId();
+
+        // when
+        stepRepository.deleteById(id);
+        stepRepository.flush();
+
+        // then
+        assertThat(stepRepository.findById(id)).isEmpty();
+    }
+
+    // --- empty results ---
+
+    @Test
+    @DisplayName("findByRecipeId — zwraca pustą listę dla nieistniejącego przepisu")
+    void findByRecipeId_returnsEmptyForNonExistentRecipe() {
+        List<Step> results = stepRepository.findByRecipeIdOrderByStepNumberAsc("non-existent-recipe");
+        assertThat(results).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findByIdAndRecipeId — zwraca empty dla nieistniejącego ID")
+    void findByIdAndRecipeId_returnsEmptyForNonExistentId() {
+        var result = stepRepository.findByIdAndRecipeId(99999L, "any-recipe");
+        assertThat(result).isEmpty();
+    }
+
+    // --- parameters (JSON conversion) ---
+
+    @Test
+    @DisplayName("save/load — poprawnie serializuje i deserializuje parameters (JSON)")
+    void parametersJsonConversion() {
+        // given
+        Map<String, Object> params = Map.of("temperature", 200, "unit", "°C", "preheated", true);
+        Step saved = stepRepository.save(Step.builder()
+                .recipeId("recipe-json")
+                .stepNumber(1)
+                .description("Piecz")
+                .action(ActionType.BAKE)
+                .parameters(params)
+                .createdAt(LocalDateTime.now())
+                .build());
+
+        // when
+        Step loaded = stepRepository.findById(saved.getId()).orElseThrow();
+
+        // then
+        assertThat(loaded.getParameters()).isNotNull();
+        assertThat(loaded.getParameters().get("temperature")).isEqualTo(200);
+        assertThat(loaded.getParameters().get("unit")).isEqualTo("°C");
+        assertThat(loaded.getParameters().get("preheated")).isEqualTo(true);
     }
 }


### PR DESCRIPTION
# Issue #12: Testy jednostkowe Step Entity

## 📌 Cel

Testy dla Step entity w main-service. Weryfikacja walidacji pól, poprawności mappingu, operacji CRUD w repozytorium oraz builder pattern / Lombok.

---

## 📦 Artefakty

### 1. `StepTest.java` *(NOWY)*
Testy jednostkowe Step entity — czyste unit testy bez Spring context.

| Grupa | Testy | Opis |
|---|---|---|
| Builder pattern | 2 | Tworzenie z wszystkimi/wymaganymi polami |
| Gettery i settery | 2 | Ustawianie wartości, null dla opcjonalnych |
| Null handling | 2 | No-arg constructor, builder z nullami |
| equals / hashCode | 4 | Identyczne, różne, null, self-equality |
| toString | 1 | Zawiera kluczowe pola |
| Optional fields | 4 | parameters (pusta/złożona mapa), durationMinutes=0, mainIngredient |
| ActionType enum | 2 | displayName, akceptacja wszystkich typów |

**Łącznie: 17 testów ✅**

---

### 2. `StepRepositoryTest.java` *(ROZSZERZONY)*

Testy repozytorium z `@SpringBootTest` + `@Transactional` + H2.

| Test | Status |
|---|---|
| save — zapisuje i generuje ID | ✅ *NOWY* |
| findById — zwraca zapisany Step | ✅ *NOWY* |
| findById — empty dla nieistniejącego ID | ✅ *NOWY* |
| findByRecipeIdOrderByStepNumberAsc — sortuje | ✅ *istniejący* |
| findByRecipeId — nie miesza przepisów | ✅ *NOWY* |
| findByIdAndRecipeId — zwraca krok | ✅ *istniejący* |
| findByIdAndRecipeId — empty gdy recipeId nie pasuje | ✅ *NOWY* |
| delete — usuwa Step | ✅ *NOWY* |
| deleteById — usuwa po ID | ✅ *NOWY* |
| findByRecipeId — pusta lista dla nieistniejącego | ✅ *NOWY* |
| findByIdAndRecipeId — empty dla nieistniejącego ID | ✅ *NOWY* |
| parameters JSON — serializacja/deserializacja | ✅ *NOWY* |

**Łącznie: 12 testów ✅** (było 2, dodano 10)

---

### 3. `StepMapperTest.java` *(ROZSZERZONY)*

Testy MapStruct mapper'a z `@SpringBootTest`.

| Test | Status |
|---|---|
| toDTO — mapuje wszystkie pola | ✅ *istniejący* |
| toDTO — null opcjonalne pola | ✅ *NOWY* |
| toEntity — mapuje DTO → entity (bez createdAt) | ✅ *istniejący* |
| null input → null output | ✅ *istniejący* |
| bidirectional: entity → DTO → entity | ✅ *NOWY* |
| bidirectional: DTO → entity → DTO | ✅ *NOWY* |
| toDTO — mapuje każdy ActionType | ✅ *NOWY* |

**Łącznie: 7 testów ✅** (było 3, dodano 4)

---

### 4. `StepValidationTest.java` *(NOWY)*

Testy Bean Validation (`jakarta.validation`) dla StepDTO.

| Grupa | Testy | Opis |
|---|---|---|
| Poprawne dane | 3 | Pełny DTO, minimalny, duration=0 |
| stepNumber | 3 | null, zero, negative |
| description | 3 | null, empty, blank (spacje) |
| action | 1 | null |
| recipeId | 2 | null, empty |
| durationMinutes | 2 | null (ok), negative (violation) |
| Multiple violations | 1 | Wiele niepoprawnych pól naraz |

**Łącznie: 15 testów ✅**

---

## 📊 Wyniki testów

```
Tests run: 51, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

| Klasa testowa | Testy | Wynik |
|---|---|---|
| `StepTest` | 17 | ✅ PASS |
| `StepRepositoryTest` | 12 | ✅ PASS |
| `StepMapperTest` | 7 | ✅ PASS |
| `StepValidationTest` | 15 | ✅ PASS |

---

## ✅ Testy akceptacyjne

- [x] Wszystkie unit testy przechodzą
- [x] Repository testy działają
- [x] Mapper testy działają
- [x] Validation testy działają
- [x] Brak warningów w testach (poza standardowymi Mockito/Spring)

---

## 📝 Uwagi

- **Istniejące testy** (`StepMapperTest` i `StepRepositoryTest`) zostały zachowane i rozszerzone o brakujące przypadki — nie usunięto żadnego istniejącego testu.
- **`StepValidationTest`** testuje walidację na `StepDTO` (nie na `Step` entity), ponieważ to DTO posiada adnotacje `@NotBlank`, `@NotNull`, `@Positive`, `@PositiveOrZero`.
- **`stepNumber`** w entity `Step` jest typu `Integer` (boxed), nie `int` (primitive) — domyślna wartość to `null`, nie `0`.
- **Brak zmian w `pom.xml`** — wszystkie potrzebne zależności już istniały (H2, spring-boot-starter-test, mockito).
