### PR TITLE
wprowadzenie realm

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,19 @@ Admin console: `http://localhost:8080/admin/master/console/`
 - Username: `admin`
 - Password: `admin`
 
+**Realm import:** Start kontenera automatycznie importuje `keycloak/realm-export.json` (Realm `cookmate`).
+
+**OIDC client (Authorization Code flow):**
+- Client ID: `cookmate-client`
+- Client Secret: `cookmate-secret`
+- Valid Redirect URIs: `http://localhost:5173/*`, `http://localhost:8081/*`
+- Web Origins: `http://localhost:5173`, `http://localhost:8081`
+
+**Test user (realm `cookmate`):**
+- Username: `test.user`
+- Password: `test12345`
+- Roles: `ROLE_USER`, `ROLE_ADMIN`
+
 **Note:** Change default credentials in production. Keycloak uses a separate PostgreSQL database (`keycloak`) for configuration, users, and sessions persistence.
 
 ## Struktura projektu
@@ -176,6 +189,8 @@ CookMate/
 │       ├── exception/*.java
 │       ├── model/*.java
 │       └── service/SimulationService.java
+├── keycloak/
+│   └── realm-export.json            # Import Realm/klientów/użytkowników Keycloak
 ├── docker-compose.yml
 └── pom.xml                         # Root Maven aggregator
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -163,6 +163,8 @@ services:
     restart: unless-stopped
     ports:
       - "8080:8080"
+    volumes:
+      - ./keycloak/realm-export.json:/opt/keycloak/data/import/realm-export.json:ro
     environment:
       KEYCLOAK_ADMIN: "${KEYCLOAK_ADMIN:-admin}"
       KEYCLOAK_ADMIN_PASSWORD: "${KEYCLOAK_ADMIN_PASSWORD:-admin}"
@@ -187,7 +189,7 @@ services:
       timeout: 10s
       retries: 5
       start_period: 90s
-    command: start-dev
+    command: ["start-dev", "--import-realm"]
 
   # ─────────────────────────────────────────────
   # Frontend Service (port 5173)

--- a/keycloak/realm-export.json
+++ b/keycloak/realm-export.json
@@ -1,0 +1,81 @@
+{
+  "id": "cookmate",
+  "realm": "cookmate",
+  "displayName": "CookMate",
+  "enabled": true,
+  "sslRequired": "external",
+  "registrationAllowed": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": true,
+  "editUsernameAllowed": false,
+  "requiredCredentials": [
+    "password"
+  ],
+  "roles": {
+    "realm": [
+      {
+        "name": "ROLE_USER",
+        "description": "Default application user role",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "cookmate"
+      },
+      {
+        "name": "ROLE_ADMIN",
+        "description": "Application administrator role",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "cookmate"
+      }
+    ]
+  },
+  "clients": [
+    {
+      "clientId": "cookmate-client",
+      "name": "CookMate OIDC Client",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "bearerOnly": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "cookmate-secret",
+      "redirectUris": [
+        "http://localhost:5173/*",
+        "http://localhost:8081/*"
+      ],
+      "webOrigins": [
+        "http://localhost:5173",
+        "http://localhost:8081"
+      ],
+      "attributes": {
+        "pkce.code.challenge.method": "S256"
+      }
+    }
+  ],
+  "users": [
+    {
+      "username": "test.user",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Test",
+      "lastName": "User",
+      "email": "test.user@cookmate.local",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "test12345",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "ROLE_USER",
+        "ROLE_ADMIN"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
- Dodano importowany Realm Keycloak: keycloak/realm-export.json (realm cookmate, role ROLE_USER/ROLE_ADMIN, klient OIDC cookmate-client, testowy użytkownik test.user). [1]( https://github.com/CookMate-Team/CookMate/blob/177-sub-issue-konfiguracja-infrastruktury-keycloak-docker-compose/keycloak/realm-export.json)
  
- Zmieniono docker-compose.yml: montowanie pliku i uruchomienie Keycloak z --import-realm. [2](https://github.com/CookMate-Team/CookMate/blob/177-sub-issue-konfiguracja-infrastruktury-keycloak-docker-compose/docker-compose.yml)
- Zaktualizowano README z danymi klienta i użytkownika. [3](https://github.com/CookMate-Team/CookMate/blob/177-sub-issue-konfiguracja-infrastruktury-keycloak-docker-compose/README.md)

Closes #178 