### PR TITLE
187 wdrożenie sonarqube

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,11 @@ networks:
 volumes:
   postgres-data:
   keycloak-data:
+  sonarqube_conf:
   sonarqube_data:
   sonarqube_extensions:
   sonarqube_logs:
+  sonarqube_temp:
 
 services:
 
@@ -220,7 +222,7 @@ services:
   # SonarQube Code Quality Platform (port 9000)
   # ─────────────────────────────────────────────
   sonarqube:
-    image: sonarqube:10.7-community
+    image: sonarqube:community
     container_name: cookmate-sonarqube
     restart: unless-stopped
     ports:
@@ -239,6 +241,8 @@ services:
         soft: 65536
         hard: 65536
     volumes:
+      - sonarqube_conf:/opt/sonarqube/conf
       - sonarqube_data:/opt/sonarqube/data
       - sonarqube_extensions:/opt/sonarqube/extensions
       - sonarqube_logs:/opt/sonarqube/logs
+      - sonarqube_temp:/opt/sonarqube/temp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -212,3 +212,26 @@ services:
         condition: service_healthy
     networks:
       - cookmate-net
+
+  # ─────────────────────────────────────────────
+  # SonarQube Code Quality Platform (port 9000)
+  # ─────────────────────────────────────────────
+  sonarqube:
+    image: sonarqube:10.7-community
+    container_name: cookmate-sonarqube
+    restart: unless-stopped
+    ports:
+      - "9000:9000"
+    environment:
+      - SONAR_JDBC_USERNAME=sonar
+      - SONAR_JDBC_PASSWORD=sonar
+      - SONAR_JDBC_URL=jdbc:postgresql://postgres:5432/sonar
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - cookmate-net
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -222,7 +222,7 @@ services:
   # SonarQube Code Quality Platform (port 9000)
   # ─────────────────────────────────────────────
   sonarqube:
-    image: sonarqube:community
+    image: sonarqube:10.7.0-community
     container_name: cookmate-sonarqube
     restart: unless-stopped
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,9 @@ networks:
 volumes:
   postgres-data:
   keycloak-data:
+  sonarqube_data:
+  sonarqube_extensions:
+  sonarqube_logs:
 
 services:
 
@@ -235,3 +238,7 @@ services:
       nofile:
         soft: 65536
         hard: 65536
+    volumes:
+      - sonarqube_data:/opt/sonarqube/data
+      - sonarqube_extensions:/opt/sonarqube/extensions
+      - sonarqube_logs:/opt/sonarqube/logs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -228,9 +228,9 @@ services:
     ports:
       - "9000:9000"
     environment:
-      - SONAR_JDBC_USERNAME=sonar
-      - SONAR_JDBC_PASSWORD=sonar
-      - SONAR_JDBC_URL=jdbc:postgresql://postgres:5432/sonar
+      SONAR_JDBC_USERNAME: "${SONAR_JDBC_USERNAME:-sonar}"
+      SONAR_JDBC_PASSWORD: "${SONAR_JDBC_PASSWORD:-sonar}"
+      SONAR_JDBC_URL: "${SONAR_JDBC_URL:-jdbc:postgresql://postgres:5432/sonar}"
     depends_on:
       postgres:
         condition: service_healthy

--- a/docs/SonarQube.md
+++ b/docs/SonarQube.md
@@ -1,0 +1,128 @@
+# Lokalne skanowanie kodu za pomocą SonarQube
+
+Niniejsza dokumentacja opisuje sposób uruchomienia serwera **SonarQube** lokalnie w środowisku Docker oraz przeprowadzania pełnej statycznej analizy kodu dla części backendowej (Java/Maven) i frontendowej (React/TypeScript).
+
+Dzięki temu każdy członek zespołu może bez instalowania lokalnych narzędzi (Maven, Node, Sonar Scanner) dokonać pełnej weryfikacji jakości kodu na swoim komputerze.
+
+---
+
+## 🛠️ Wymagania wstępne
+
+Przed rozpoczęciem upewnij się, że masz zainstalowane i uruchomione:
+1. **Docker Desktop** (lub Docker Engine w systemie Linux/macOS).
+2. **Git Bash** (zalecany terminal dla użytkowników systemu Windows).
+
+---
+
+## 🚀 Krok 1: Uruchomienie serwera SonarQube
+
+Wszystkie potrzebne serwisy są już zdefiniowane w pliku `docker-compose.yml` w katalogu głównym projektu.
+
+1. Otwórz terminal w głównym katalogu projektu i uruchom bazę danych oraz serwer SonarQube:
+   ```bash
+   docker compose up -d postgres sonarqube
+   ```
+2. Poczekaj chwilę, aż serwer SonarQube w pełni się uruchomi (może to zająć od 1 do 2 minut przy pierwszym uruchomieniu).
+3. Wejdź w przeglądarce pod adres:
+   👉 **[http://localhost:9000](http://localhost:9000)**
+4. Zaloguj się domyślnymi danymi:
+   * **Login:** `admin`
+   * **Hasło:** `admin`
+5. **Wymagana zmiana hasła:** Przy pierwszym logowaniu SonarQube wymusi ustawienie nowego hasła. Zapamiętaj je lub zapisz.
+
+---
+
+## 🔑 Krok 2: Generowanie tokenu dostępu
+
+Token dostępu (Analysis Token) jest potrzebny, aby skanery mogły uwierzytelnić się w Twoim lokalnym serwerze SonarQube.
+
+1. Po zalogowaniu kliknij ikonę swojego profilu w prawym górnym rogu.
+2. Wybierz **My Account**, a następnie zakładkę **Security**.
+3. W sekcji **Generate Tokens**:
+   * Podaj nazwę tokenu (np. `cookmate-token`).
+   * Jako typ wybierz **User Token** lub **Global Analysis Token**.
+   * Kliknij **Generate**.
+4. ⚠️ **Skopiuj wygenerowany token!** Pokazuje się on tylko raz. Będzie Ci potrzebny w kolejnych krokach jako `TWÓJ_TOKEN`.
+
+---
+
+## ☕ Krok 3: Skanowanie kodu Backendu (Java)
+
+Analiza backendu uruchamia testy jednostkowe i integracyjne, generuje raport pokrycia kodu (JaCoCo), a następnie wysyła te dane do SonarQube.
+
+Uruchom poniższe polecenie w głównym katalogu projektu w terminalu **Git Bash**:
+
+```bash
+MSYS_NO_PATHCONV=1 docker run --rm -it \
+  -v "$(pwd):/app" \
+  -w /app \
+  --network cookmate_cookmate-net \
+  maven:3.9-eclipse-temurin-25 \
+  mvn clean verify sonar:sonar \
+  "-Dsonar.host.url=http://cookmate-sonarqube:9000" \
+  "-Dsonar.login=TWÓJ_TOKEN"
+```
+
+*Zastąp `TWÓJ_TOKEN` wartością skopiowaną w Kroku 2.*
+
+> [!NOTE]
+> Zmienna `MSYS_NO_PATHCONV=1` zapobiega problemom z tłumaczeniem ścieżek wolumenów w konsoli Git Bash w systemie Windows. Jest ona absolutnie wymagana.
+
+---
+
+## ⚛️ Krok 4: Skanowanie kodu Frontendu (TypeScript)
+
+Skanowanie frontendowe składa się z dwóch etapów: wygenerowania raportu z lintera (ESLint) oraz właściwej analizy Sonar Scannera.
+
+### A. Generowanie raportu z lintera
+Uruchom w głównym katalogu projektu:
+
+```bash
+MSYS_NO_PATHCONV=1 docker run --rm \
+  -v "$(pwd)/frontend:/app" \
+  -w /app \
+  node:20-alpine \
+  sh -c "npm install && npm run lint:sonar"
+```
+
+*Komenda ta zainstaluje zależności i utworzy plik `frontend/eslint-report.json` (który jest ignorowany przez Gita).*
+
+### B. Uruchomienie skanera SonarQube
+Uruchom w głównym katalogu projektu:
+
+```bash
+MSYS_NO_PATHCONV=1 docker run --rm \
+  -v "$(pwd)/frontend:/usr/src" \
+  --network cookmate_cookmate-net \
+  sonarsource/sonar-scanner-cli \
+  -Dsonar.host.url=http://cookmate-sonarqube:9000 \
+  -Dsonar.login=TWÓJ_TOKEN
+```
+
+---
+
+## 📊 Krok 5: Podgląd wyników i konfiguracja Quality Gate
+
+Po pomyślnym zakończeniu obu skanowań wejdź na **[http://localhost:9000](http://localhost:9000)**. Zobaczysz tam dwa osobne projekty:
+1. **CookMate Parent** (Backend) – zawiera pokrycie kodu testami z JaCoCo, błędy Java oraz metryki długu technologicznego.
+2. **CookMate Frontend** – zawiera analizę TypeScriptu oraz zaczytane reguły z ESLint.
+
+### Wdrożenie własnego Quality Gate (Zalecane)
+Domyślnie SonarQube stosuje profil *Sonar way*. Aby stworzyć reguły blokujące kod o niskiej jakości dla zespołu:
+1. W panelu górnym kliknij **Quality Gates** -> **Create**.
+2. Nazwij go np. `CookMate Gate`.
+3. Kliknij **Add Condition** i ustaw pożądane progi akceptacji, na przykład:
+   * **Bugs** (Błędy) > `0` (na Nowym Kodzie)
+   * **Coverage** (Pokrycie kodu) < `50%` (na Nowym Kodzie)
+   * **Duplicated Lines (%)** (Duplikaty) > `5%`
+4. Na dole strony w sekcji **Projects** przypisz ten Quality Gate do projektów `cookmate-parent` oraz `cookmate-frontend`.
+
+---
+
+## 🔄 Czyszczenie środowiska (Gdy chcesz zacząć od nowa)
+
+Jeśli chcesz całkowicie usunąć dane SonarQube i jego bazę danych, aby zacząć konfigurację od zera, wykonaj:
+```bash
+docker compose down -v
+```
+*(Flaga `-v` usunie wolumeny Dockera powiązane z bazą danych i plikami SonarQube).*

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -22,3 +22,7 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# SonarQube Reports
+eslint-report.json
+

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "lint:sonar": "eslint . --format json -o eslint-report.json || true",
+    "lint:sonar": "eslint . --format json -o eslint-report.json || exit 0",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "lint:sonar": "eslint . --format json -o eslint-report.json || true",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "lint:sonar": "eslint . --format json -o eslint-report.json || exit 0",
+    "lint:sonar": "eslint . --format json -o eslint-report.json; status=$?; if [ $status -eq 1 ]; then exit 0; fi; exit $status",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/frontend/sonar-project.properties
+++ b/frontend/sonar-project.properties
@@ -1,0 +1,8 @@
+sonar.projectKey=cookmate-frontend
+sonar.projectName=CookMate Frontend
+sonar.sources=src
+sonar.tests=src
+sonar.test.inclusions=**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx
+sonar.exclusions=node_modules/**,dist/**,vite.config.ts,eslint.config.js,tailwind.config.js
+sonar.language=ts
+sonar.eslint.reportPaths=eslint-report.json

--- a/init-postgres.sql
+++ b/init-postgres.sql
@@ -26,3 +26,19 @@ GRANT ALL PRIVILEGES ON DATABASE keycloak TO keycloak;
 ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL PRIVILEGES ON TABLES TO keycloak;
 ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL PRIVILEGES ON SEQUENCES TO keycloak;
 ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO keycloak;
+
+-- ============================================================================
+-- SonarQube Database Setup
+-- ============================================================================
+
+-- Create sonarqube database user (if not exists)
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT FROM pg_user WHERE usename = 'sonar') THEN
+    CREATE USER sonar WITH PASSWORD 'sonar';
+  END IF;
+END $$;
+
+-- Create sonarqube database
+CREATE DATABASE sonar OWNER sonar ENCODING 'UTF8';
+GRANT ALL PRIVILEGES ON DATABASE sonar TO sonar;

--- a/main-service/pom.xml
+++ b/main-service/pom.xml
@@ -163,6 +163,25 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/main-service/src/test/java/com/cookmate/main/integration/DiscoveryIntegrationTest.java
+++ b/main-service/src/test/java/com/cookmate/main/integration/DiscoveryIntegrationTest.java
@@ -13,6 +13,7 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
@@ -29,6 +30,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 @Import(DiscoveryIntegrationTest.StubMealDbApiConfig.class)
+@ActiveProfiles("test")
 class DiscoveryIntegrationTest {
 
     @Autowired

--- a/main-service/src/test/resources/application-test.yml
+++ b/main-service/src/test/resources/application-test.yml
@@ -4,6 +4,18 @@ spring:
       enabled: false  # Wyłącza szukanie Config Servera
     discovery:
       enabled: false # Wyłącza Discovery
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
 eureka:
   client:
     enabled: false   # Wyłącza klienta Eureka

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,18 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        
+        <!-- SonarQube Quality Properties -->
+        <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
+        <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
+        <sonar.exclusions>
+            **/dto/**,
+            **/model/**,
+            **/config/**,
+            **/*Application.java,
+            **/exception/**,
+            **/entity/**
+        </sonar.exclusions>
     </properties>
 
     <dependencyManagement>
@@ -45,4 +57,21 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.sonarsource.scanner.maven</groupId>
+                    <artifactId>sonar-maven-plugin</artifactId>
+                    <version>4.0.0.4121</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>0.8.12</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -27,8 +27,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         
         <!-- SonarQube Quality Properties -->
-        <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
-        <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
         <sonar.exclusions>
             **/dto/**,
             **/model/**,

--- a/pom.xml
+++ b/pom.xml
@@ -59,19 +59,17 @@
     </dependencyManagement>
 
     <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.sonarsource.scanner.maven</groupId>
-                    <artifactId>sonar-maven-plugin</artifactId>
-                    <version>4.0.0.4121</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.jacoco</groupId>
-                    <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.12</version>
-                </plugin>
-            </plugins>
-        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.sonarsource.scanner.maven</groupId>
+                <artifactId>sonar-maven-plugin</artifactId>
+                <version>4.0.0.4121</version>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.12</version>
+            </plugin>
+        </plugins>
     </build>
 </project>

--- a/simulator-service/pom.xml
+++ b/simulator-service/pom.xml
@@ -168,6 +168,25 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
This pull request introduces full support for local static code analysis using SonarQube for both the backend (Java/Maven) and frontend (React/TypeScript) parts of the project. It adds SonarQube as a Docker service, configures database and volume persistence, provides documentation for local usage, and integrates code coverage and linting reports into the CI workflow. The changes are grouped below by theme.

**SonarQube Integration and Docker Setup:**

* Added SonarQube as a service in `docker-compose.yml`, including required volumes for configuration, data, logs, and extensions, and set up environment variables for database connectivity. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R8-R12) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R220-R248)
* Extended the PostgreSQL initialization script to create a dedicated SonarQube database and user.

**Documentation:**

* Added a comprehensive `docs/SonarQube.md` guide (in Polish) detailing how to run SonarQube locally, generate tokens, and perform code scans for both backend and frontend.

**Backend (Java/Maven) Configuration:**

* Integrated the JaCoCo Maven plugin into both backend services (`main-service` and `simulator-service`) to generate code coverage reports required by SonarQube. [[1]](diffhunk://#diff-b7ab597299eef46ad967acd1e79726d760263980d550b8130dcce5e89c27ebe5R166-R184) [[2]](diffhunk://#diff-faf7340279f1d900d14fdf6ccdf44d016e8286f9569858450f487e722dd5655eR171-R189)
* Updated the root `pom.xml` to include SonarQube plugin management and set project-wide SonarQube properties, including exclusions for generated/model/config classes. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R28-R39) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R60-R76)

**Frontend (React/TypeScript) Configuration:**

* Added a SonarQube project properties file and a new npm script (`lint:sonar`) to generate ESLint reports in JSON format for SonarQube ingestion. [[1]](diffhunk://#diff-8b22cde35788a01d5a06d045770f2ca27d54d7d201a655f24e839d0801e53448R1-R8) [[2]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655R10)
* Updated `.gitignore` to exclude the generated `eslint-report.json` from version control.

**Test & Profile Improvements:**

* Set the `test` Spring profile for integration tests and configured H2 in-memory database for isolated test runs. [[1]](diffhunk://#diff-e3a66d39ecf072bf5109cd2722201e72b879ea2a49aa583f7b9213ee5e26fe22R16) [[2]](diffhunk://#diff-e3a66d39ecf072bf5109cd2722201e72b879ea2a49aa583f7b9213ee5e26fe22R33) [[3]](diffhunk://#diff-a9fdd3ca41a0f93a5843d2ec97024e68c4cb28edaa343e163ca2e3e5dbde193bR7-R18)

These changes collectively enable team members to perform full-featured local code quality analysis and coverage reporting using SonarQube with minimal setup.