### PR TITLE
191 tests testy bdd cucumber dla recipe api

### DIFF
--- a/main-service/src/test/java/com/cookmate/main/cucumber/RecipeSteps.java
+++ b/main-service/src/test/java/com/cookmate/main/cucumber/RecipeSteps.java
@@ -1,6 +1,7 @@
 package com.cookmate.main.cucumber;
 
 import com.cookmate.main.controller.RecipeController;
+import com.cookmate.main.exception.GlobalExceptionHandler;
 import com.cookmate.main.exception.RecipeNotFoundException;
 import com.cookmate.main.model.Recipe;
 import com.cookmate.main.service.RecipeService;
@@ -44,7 +45,9 @@ public class RecipeSteps {
         when(stepService.getStepsByRecipeId(any())).thenReturn(List.of());
 
         RecipeController controller = new RecipeController(recipeService, stepService);
-        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
     }
 
     @Given("the recipe repository contains {int} recipes")
@@ -81,7 +84,7 @@ public class RecipeSteps {
                 .thenReturn(new com.cookmate.main.dto.RecipeListResponse(List.of(), 0, 10, 0, 0));
     }
 
-    @When("I call GET {string}")
+    @When("I send GET {string}")
     public void iCallGet(String path) throws Exception {
         lastResult = mockMvc.perform(get(path)
                         .contentType(MediaType.APPLICATION_JSON))
@@ -109,7 +112,7 @@ public class RecipeSteps {
                 .andReturn();
     }
 
-    @Then("the response status should be {int}")
+    @Then("the recipe response status should be {int}")
     public void theResponseStatusShouldBe(int expectedStatus) {
         assertThat(lastResult.getResponse().getStatus())
                 .as("Expected HTTP status %d", expectedStatus)
@@ -128,7 +131,7 @@ public class RecipeSteps {
                 .isTrue();
     }
 
-    @And("the response should contain field {string}")
+    @And("the recipe response should contain field {string}")
     public void theResponseShouldContainField(String fieldName) throws Exception {
         var body = lastResult.getResponse().getContentAsString();
         JsonNode json = objectMapper.readTree(body);

--- a/main-service/src/test/java/com/cookmate/main/cucumber/RecipeSteps.java
+++ b/main-service/src/test/java/com/cookmate/main/cucumber/RecipeSteps.java
@@ -1,4 +1,151 @@
 package com.cookmate.main.cucumber;
 
+import com.cookmate.main.controller.RecipeController;
+import com.cookmate.main.exception.RecipeNotFoundException;
+import com.cookmate.main.model.Recipe;
+import com.cookmate.main.service.RecipeService;
+import com.cookmate.main.service.StepService;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.cucumber.java.Before;
+import io.cucumber.java.en.And;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import org.mockito.Mockito;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
 public class RecipeSteps {
+    private RecipeService recipeService;
+    private StepService stepService;
+    private MockMvc mockMvc;
+    private MvcResult lastResult;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Before
+    public void setUp() {
+        recipeService = Mockito.mock(RecipeService.class);
+        stepService = Mockito.mock(StepService.class);
+
+        when(stepService.getStepsByRecipeId(any())).thenReturn(List.of());
+
+        RecipeController controller = new RecipeController(recipeService, stepService);
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+    }
+
+    @Given("the recipe repository contains {int} recipes")
+    public void theRepositoryContainsRecipes(int count) {
+        var recipes = java.util.stream.IntStream.range(0, count)
+                .mapToObj(i -> new Recipe("Recipe " + i, "Description " + i, "Ingredients " + i, "Instructions " + i, 30))
+                .toList();
+
+        var recipeDtos = recipes.stream()
+                .map(r -> new com.cookmate.main.dto.RecipeDTO(
+                        (long) recipes.indexOf(r) + 1,
+                        r.getName(), r.getDescription(),
+                        r.getIngredients(), r.getInstructions(),
+                        r.getPreparationTimeMinutes(), null))
+                .toList();
+
+        when(recipeService.findPaginated(0, 10))
+                .thenReturn(new com.cookmate.main.dto.RecipeListResponse(recipeDtos, 0, 10, count, 1));
+    }
+
+    @Given("a recipe with id {long} exists in the repository")
+    public void aRecipeWithIdExists(long id) {
+        var recipe = new Recipe("Test Recipe", "A description", "flour, eggs", "Mix and bake", 60);
+        when(recipeService.findByIdOrThrow(id)).thenReturn(recipe);
+    }
+
+    @Given("the recipe repository is empty")
+    public void theRepositoryIsEmpty() {
+        when(recipeService.findByIdOrThrow(anyLong()))
+                .thenThrow(new RecipeNotFoundException(99999L));
+        doThrow(new RecipeNotFoundException(99999L))
+                .when(recipeService).deleteByIdOrThrow(anyLong());
+        when(recipeService.findPaginated(0, 10))
+                .thenReturn(new com.cookmate.main.dto.RecipeListResponse(List.of(), 0, 10, 0, 0));
+    }
+
+    @When("I call GET {string}")
+    public void iCallGet(String path) throws Exception {
+        lastResult = mockMvc.perform(get(path)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andReturn();
+    }
+
+    @When("I call POST {string} with body:")
+    public void iCallPostWithBody(String path, String body) throws Exception {
+        if (!body.contains("\"name\": \"\"")) {
+            var recipe = new Recipe("Spaghetti Bolognese", "Classic Italian pasta dish",
+                    "spaghetti, minced meat, tomato sauce", "Cook pasta, prepare sauce, combine", 45);
+            when(recipeService.save(any())).thenReturn(recipe);
+        }
+
+        lastResult = mockMvc.perform(post(path)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andReturn();
+    }
+
+    @When("I call DELETE {string}")
+    public void iCallDelete(String path) throws Exception {
+        lastResult = mockMvc.perform(delete(path)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andReturn();
+    }
+
+    @Then("the response status should be {int}")
+    public void theResponseStatusShouldBe(int expectedStatus) {
+        assertThat(lastResult.getResponse().getStatus())
+                .as("Expected HTTP status %d", expectedStatus)
+                .isEqualTo(expectedStatus);
+    }
+
+    @And("the response should contain a recipes array")
+    public void theResponseShouldContainARecipesArray() throws Exception {
+        var body = lastResult.getResponse().getContentAsString();
+        JsonNode json = objectMapper.readTree(body);
+        assertThat(json.has("recipes"))
+                .as("Response should have 'recipes' field")
+                .isTrue();
+        assertThat(json.get("recipes").isArray())
+                .as("'recipes' should be an array")
+                .isTrue();
+    }
+
+    @And("the response should contain field {string}")
+    public void theResponseShouldContainField(String fieldName) throws Exception {
+        var body = lastResult.getResponse().getContentAsString();
+        JsonNode json = objectMapper.readTree(body);
+        assertThat(json.has(fieldName))
+                .as("Response should contain field '%s'", fieldName)
+                .isTrue();
+    }
+
+    @And("the response should contain error code {string}")
+    public void theResponseShouldContainErrorCode(String expectedCode) throws Exception {
+        var body = lastResult.getResponse().getContentAsString();
+        JsonNode json = objectMapper.readTree(body);
+        assertThat(json.has("code"))
+                .as("Response should have 'code' field")
+                .isTrue();
+        assertThat(json.get("code").asText())
+                .as("Error code should be '%s'", expectedCode)
+                .isEqualTo(expectedCode);
+    }
 }

--- a/main-service/src/test/java/com/cookmate/main/cucumber/RecipeSteps.java
+++ b/main-service/src/test/java/com/cookmate/main/cucumber/RecipeSteps.java
@@ -1,0 +1,4 @@
+package com.cookmate.main.cucumber;
+
+public class RecipeSteps {
+}

--- a/main-service/src/test/resources/features/recipe-management.feature
+++ b/main-service/src/test/resources/features/recipe-management.feature
@@ -5,20 +5,20 @@ Feature: Recipe management endpoints
 
   Scenario: Get all recipes returns 200 and recipes array
     Given the recipe repository contains 2 recipes
-    When I call GET "/api/recipes"
-    Then the response status should be 200
+    When I send GET "/api/recipes"
+    Then the recipe response status should be 200
     And the response should contain a recipes array
 
   Scenario: Get recipe by existing ID returns 200
     Given a recipe with id 1 exists in the repository
-    When I call GET "/api/recipes/1"
-    Then the response status should be 200
-    And the response should contain field "name"
+    When I send GET "/api/recipes/1"
+    Then the recipe response status should be 200
+    And the recipe response should contain field "name"
 
   Scenario: Get recipe by non-existing ID returns 404
     Given the recipe repository is empty
-    When I call GET "/api/recipes/99999"
-    Then the response status should be 404
+    When I send GET "/api/recipes/99999"
+    Then the recipe response status should be 404
     And the response should contain error code "RECIPE_NOT_FOUND"
 
   Scenario: Create a valid recipe returns 201
@@ -32,8 +32,8 @@ Feature: Recipe management endpoints
         "preparationTimeMinutes": 45
       }
       """
-    Then the response status should be 201
-    And the response should contain field "name"
+    Then the recipe response status should be 201
+    And the recipe response should contain field "name"
 
   Scenario: Create recipe with blank name returns 400
     When I call POST "/api/recipes" with body:
@@ -44,10 +44,10 @@ Feature: Recipe management endpoints
         "preparationTimeMinutes": 10
       }
       """
-    Then the response status should be 400
+    Then the recipe response status should be 400
 
   Scenario: Delete non-existing recipe returns 404
     Given the recipe repository is empty
     When I call DELETE "/api/recipes/99999"
-    Then the response status should be 404
+    Then the recipe response status should be 404
     And the response should contain error code "RECIPE_NOT_FOUND"

--- a/main-service/src/test/resources/features/recipe-management.feature
+++ b/main-service/src/test/resources/features/recipe-management.feature
@@ -1,0 +1,53 @@
+Feature: Recipe management endpoints
+  As an API client
+  I want to create, retrieve and delete recipes
+  So that I can manage the recipe collection in CookMate
+
+  Scenario: Get all recipes returns 200 and recipes array
+    Given the recipe repository contains 2 recipes
+    When I call GET "/api/recipes"
+    Then the response status should be 200
+    And the response should contain a recipes array
+
+  Scenario: Get recipe by existing ID returns 200
+    Given a recipe with id 1 exists in the repository
+    When I call GET "/api/recipes/1"
+    Then the response status should be 200
+    And the response should contain field "name"
+
+  Scenario: Get recipe by non-existing ID returns 404
+    Given the recipe repository is empty
+    When I call GET "/api/recipes/99999"
+    Then the response status should be 404
+    And the response should contain error code "RECIPE_NOT_FOUND"
+
+  Scenario: Create a valid recipe returns 201
+    When I call POST "/api/recipes" with body:
+      """
+      {
+        "name": "Spaghetti Bolognese",
+        "description": "Classic Italian pasta dish",
+        "ingredients": "spaghetti, minced meat, tomato sauce",
+        "instructions": "Cook pasta, prepare sauce, combine",
+        "preparationTimeMinutes": 45
+      }
+      """
+    Then the response status should be 201
+    And the response should contain field "name"
+
+  Scenario: Create recipe with blank name returns 400
+    When I call POST "/api/recipes" with body:
+      """
+      {
+        "name": "",
+        "ingredients": "some ingredients",
+        "preparationTimeMinutes": 10
+      }
+      """
+    Then the response status should be 400
+
+  Scenario: Delete non-existing recipe returns 404
+    Given the recipe repository is empty
+    When I call DELETE "/api/recipes/99999"
+    Then the response status should be 404
+    And the response should contain error code "RECIPE_NOT_FOUND"


### PR DESCRIPTION
## Opis
Dodanie testów BDD (Cucumber + AssertJ) dla Recipe API. Wcześniej projekt posiadał tylko jeden plik `.feature` pokrywający Discovery API — ten PR uzupełnia brakujące scenariusze dla głównego Recipe API.

## Zmiany
- Nowy plik `recipe-management.feature` z 6 scenariuszami Gherkin
- Nowy plik `RecipeSteps.java` z implementacją kroków Given/When/Then
- Użycie AssertJ (`assertThat`) zamiast JUnit assertions
- Dodanie `GlobalExceptionHandler` do standalone MockMvc dla poprawnej obsługi błędów

## Scenariusze
- Pobranie listy przepisów zwraca 200 i tablicę
- Pobranie przepisu po ID zwraca 200
- Pobranie nieistniejącego przepisu zwraca 404 z kodem `RECIPE_NOT_FOUND`
- Utworzenie przepisu zwraca 201
- Próba utworzenia przepisu z pustą nazwą zwraca 400
- Usunięcie nieistniejącego przepisu zwraca 404 z kodem `RECIPE_NOT_FOUND`

## Uwagi techniczne
Aktualnie `RecipeSteps` i `DiscoverySteps` używają osobnych instancji MockMvc i rozróżniają kroki przez różne nazewnictwo. W przyszłości warto rozważyć wprowadzenie wspólnej klasy np. `ScenarioContext` przechowującej współdzielony stan (np. `lastResult`) między klasami Steps — pozwoliłoby to ujednolicić nazewnictwo kroków i ułatwić rozbudowę testów BDD.

Closes #191 