### PR TITLE
180 sub issue konfiguracja mikroserwisów jako spring security resource servers

### DIFF
--- a/config-repo/application.yml
+++ b/config-repo/application.yml
@@ -20,5 +20,5 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          issuer-uri: ${KEYCLOAK_INTERNAL_URL:http://keycloak:8080}/realms/cookmate
+          issuer-uri: ${KEYCLOAK_PUBLIC_URL:http://localhost:8080}/realms/cookmate
           jwk-set-uri: ${KEYCLOAK_INTERNAL_URL:http://keycloak:8080}/realms/cookmate/protocol/openid-connect/certs

--- a/config-repo/application.yml
+++ b/config-repo/application.yml
@@ -12,3 +12,13 @@ logging:
   level:
     com.cookmate: DEBUG
     org.springframework.cloud: INFO
+
+# Centralized OAuth2 Resource Server configuration for all business microservices
+# Each service validates JWT tokens issued by Keycloak
+spring:
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: ${KEYCLOAK_INTERNAL_URL:http://keycloak:8080}/realms/cookmate
+          jwk-set-uri: ${KEYCLOAK_INTERNAL_URL:http://keycloak:8080}/realms/cookmate/protocol/openid-connect/certs

--- a/config-repo/gateway-service.yml
+++ b/config-repo/gateway-service.yml
@@ -23,7 +23,7 @@ spring:
             user-name-attribute: preferred_username
       resourceserver:
         jwt:
-          issuer-uri: ${KEYCLOAK_INTERNAL_URL:http://keycloak:8080}/realms/cookmate
+          issuer-uri: ${KEYCLOAK_PUBLIC_URL:http://localhost:8080}/realms/cookmate
           jwk-set-uri: ${KEYCLOAK_INTERNAL_URL:http://keycloak:8080}/realms/cookmate/protocol/openid-connect/certs
 
 
@@ -58,7 +58,12 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,info,metrics
+        include: "*"
   endpoint:
     health:
       show-details: always
+
+logging:
+  level:
+    org.springframework.cloud.gateway: TRACE
+    org.springframework.web.reactive: TRACE

--- a/config-repo/gateway-service.yml
+++ b/config-repo/gateway-service.yml
@@ -21,6 +21,11 @@ spring:
             user-info-uri: ${KEYCLOAK_INTERNAL_URL:http://keycloak:8080}/realms/cookmate/protocol/openid-connect/userinfo
             jwk-set-uri: ${KEYCLOAK_INTERNAL_URL:http://keycloak:8080}/realms/cookmate/protocol/openid-connect/certs
             user-name-attribute: preferred_username
+      resourceserver:
+        jwt:
+          issuer-uri: ${KEYCLOAK_INTERNAL_URL:http://keycloak:8080}/realms/cookmate
+          jwk-set-uri: ${KEYCLOAK_INTERNAL_URL:http://keycloak:8080}/realms/cookmate/protocol/openid-connect/certs
+
 
   cloud:
     gateway:

--- a/config-repo/gateway-service.yml
+++ b/config-repo/gateway-service.yml
@@ -29,30 +29,32 @@ spring:
 
   cloud:
     gateway:
-      default-filters:
-        - SaveSession
-      routes:
-        - id: simulator-service
-          uri: lb://simulator-service
-          predicates:
-            - Path=/api/simulator/**
-          filters:
-            - TokenRelay
-          order: 0
-        - id: cooking-session-service
-          uri: lb://cooking-session-service
-          predicates:
-            - Path=/api/cooking-sessions/**
-          filters:
-            - TokenRelay
-          order: 1
-        - id: main-service
-          uri: lb://main-service
-          predicates:
-            - Path=/api/**
-          filters:
-            - TokenRelay
-          order: 2
+      server:
+        webflux:
+          default-filters:
+            - SaveSession
+          routes:
+            - id: simulator-service
+              uri: lb://simulator-service
+              predicates:
+                - Path=/api/simulator/**
+              filters:
+                - TokenRelay
+              order: 0
+            - id: cooking-session-service
+              uri: lb://cooking-session-service
+              predicates:
+                - Path=/api/cooking-sessions/**
+              filters:
+                - TokenRelay
+              order: 1
+            - id: main-service
+              uri: lb://main-service
+              predicates:
+                - Path=/api/**
+              filters:
+                - TokenRelay
+              order: 2
 
 management:
   endpoints:

--- a/cooking-session-service/pom.xml
+++ b/cooking-session-service/pom.xml
@@ -70,12 +70,29 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
 
+        <!-- OAuth2 Resource Server (JWT validation) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+
+
         <!-- Test -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>

--- a/cooking-session-service/pom.xml
+++ b/cooking-session-service/pom.xml
@@ -98,11 +98,7 @@
             <artifactId>h2</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-webmvc-test</artifactId>
-            <scope>test</scope>
-        </dependency>
+
     </dependencies>
 
     <dependencyManagement>

--- a/cooking-session-service/src/main/java/com/cookmate/cookingsession/config/KeycloakJwtAuthenticationConverter.java
+++ b/cooking-session-service/src/main/java/com/cookmate/cookingsession/config/KeycloakJwtAuthenticationConverter.java
@@ -1,0 +1,59 @@
+package com.cookmate.cookingsession.config;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Converts Keycloak JWT tokens into Spring Security authentication tokens.
+ * <p>
+ * Keycloak stores realm roles under the {@code realm_access.roles} claim.
+ * This converter extracts those roles and maps them to Spring Security
+ * {@link GrantedAuthority} instances with the {@code ROLE_} prefix.
+ */
+@Component
+public class KeycloakJwtAuthenticationConverter implements Converter<Jwt, AbstractAuthenticationToken> {
+
+    private static final String REALM_ACCESS_CLAIM = "realm_access";
+    private static final String ROLES_KEY = "roles";
+    private static final String ROLE_PREFIX = "ROLE_";
+
+    @Override
+    public AbstractAuthenticationToken convert(Jwt jwt) {
+        Collection<GrantedAuthority> authorities = extractRealmRoles(jwt);
+        return new JwtAuthenticationToken(jwt, authorities, jwt.getClaimAsString("preferred_username"));
+    }
+
+    private Collection<GrantedAuthority> extractRealmRoles(Jwt jwt) {
+        Map<String, Object> realmAccess = jwt.getClaimAsMap(REALM_ACCESS_CLAIM);
+        if (realmAccess == null || !realmAccess.containsKey(ROLES_KEY)) {
+            return Collections.emptyList();
+        }
+
+        @SuppressWarnings("unchecked")
+        List<String> roles = (List<String>) realmAccess.get(ROLES_KEY);
+
+        return roles.stream()
+                .map(this::toGrantedAuthority)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Ensures each role has exactly one ROLE_ prefix, regardless of whether
+     * Keycloak defines them with or without the prefix.
+     */
+    private GrantedAuthority toGrantedAuthority(String role) {
+        String normalizedRole = role.startsWith(ROLE_PREFIX) ? role : ROLE_PREFIX + role;
+        return new SimpleGrantedAuthority(normalizedRole);
+    }
+}

--- a/cooking-session-service/src/main/java/com/cookmate/cookingsession/config/SecurityConfig.java
+++ b/cooking-session-service/src/main/java/com/cookmate/cookingsession/config/SecurityConfig.java
@@ -1,0 +1,48 @@
+package com.cookmate.cookingsession.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.config.annotation.method.configuration.EnableReactiveMethodSecurity;
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.oauth2.server.resource.authentication.ReactiveJwtAuthenticationConverterAdapter;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+import org.springframework.security.web.server.authentication.HttpStatusServerEntryPoint;
+import org.springframework.security.web.server.authorization.HttpStatusServerAccessDeniedHandler;
+
+/**
+ * Reactive security configuration for cooking-session-service acting as an OAuth2 Resource Server.
+ * <p>
+ * This service uses WebFlux, so the security configuration is reactive.
+ * All API endpoints require authentication via a valid JWT token.
+ * Fine-grained role-based access is enforced at the method level using {@code @PreAuthorize}.
+ * Actuator health and info endpoints are publicly accessible for monitoring.
+ */
+@Configuration
+@EnableWebFluxSecurity
+@EnableReactiveMethodSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http,
+                                                         KeycloakJwtAuthenticationConverter jwtAuthenticationConverter) {
+        ReactiveJwtAuthenticationConverterAdapter reactiveConverter =
+                new ReactiveJwtAuthenticationConverterAdapter(jwtAuthenticationConverter);
+
+        return http
+                .csrf(ServerHttpSecurity.CsrfSpec::disable)
+                .authorizeExchange(auth -> auth
+                        .pathMatchers("/actuator/health", "/actuator/info").permitAll()
+                        .anyExchange().authenticated()
+                )
+                .oauth2ResourceServer(oauth2 -> oauth2
+                        .jwt(jwt -> jwt.jwtAuthenticationConverter(reactiveConverter))
+                )
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(new HttpStatusServerEntryPoint(HttpStatus.UNAUTHORIZED))
+                        .accessDeniedHandler(new HttpStatusServerAccessDeniedHandler(HttpStatus.FORBIDDEN))
+                )
+                .build();
+    }
+}

--- a/cooking-session-service/src/main/java/com/cookmate/cookingsession/controller/CookingSessionController.java
+++ b/cooking-session-service/src/main/java/com/cookmate/cookingsession/controller/CookingSessionController.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -28,6 +29,7 @@ public class CookingSessionController {
     private final CookingSessionService cookingSessionService;
 
     @PostMapping("/progress")
+    @PreAuthorize("hasRole('ROLE_USER')")
     public ResponseEntity<CookingSessionProgressDto> receiveProgress(
             @Valid @RequestBody StepCompletionEventDto event
     ) {

--- a/cooking-session-service/src/main/java/com/cookmate/cookingsession/controller/CookingSessionController.java
+++ b/cooking-session-service/src/main/java/com/cookmate/cookingsession/controller/CookingSessionController.java
@@ -69,6 +69,7 @@ public class CookingSessionController {
     }
 
     @PostMapping("/sessions/{sessionId}/complete")
+    @PreAuthorize("hasRole('ROLE_USER')")
     public ResponseEntity<Void> completeSession(
             @PathVariable String sessionId
     ) {

--- a/cooking-session-service/src/test/java/com/cookmate/cookingsession/config/SecurityFilterTest.java
+++ b/cooking-session-service/src/test/java/com/cookmate/cookingsession/config/SecurityFilterTest.java
@@ -1,0 +1,78 @@
+package com.cookmate.cookingsession.config;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+/**
+ * Security filter tests for cooking-session-service (reactive/WebFlux).
+ * Verifies that:
+ * - Requests without a JWT token return 401 Unauthorized
+ * - Public endpoints (actuator) are accessible without authentication
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@DisplayName("cooking-session-service — Security Filter Tests")
+class SecurityFilterTest {
+
+    private WebTestClient webTestClient;
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    void setUp() {
+        webTestClient = WebTestClient.bindToServer()
+                .baseUrl("http://localhost:" + port)
+                .build();
+    }
+
+    // ─── 401 Unauthorized (no token) ───────────────────────────
+
+    @Test
+    @DisplayName("POST /api/cooking-sessions/progress without token → 401")
+    void postProgress_withoutToken_returns401() {
+        webTestClient.post()
+                .uri("/api/cooking-sessions/progress")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("""
+                        {"recipeId":"52772","stepNumber":1,"completed":true}
+                        """)
+                .exchange()
+                .expectStatus().isUnauthorized();
+    }
+
+    @Test
+    @DisplayName("GET /api/cooking-sessions/recipes/xyz/history without token → 401")
+    void getHistory_withoutToken_returns401() {
+        webTestClient.get()
+                .uri("/api/cooking-sessions/recipes/xyz/history")
+                .exchange()
+                .expectStatus().isUnauthorized();
+    }
+
+    @Test
+    @DisplayName("POST /api/cooking-sessions/sessions/xyz/complete without token → 401")
+    void completeSession_withoutToken_returns401() {
+        webTestClient.post()
+                .uri("/api/cooking-sessions/sessions/xyz/complete")
+                .exchange()
+                .expectStatus().isUnauthorized();
+    }
+
+    // ─── Public endpoints ──────────────────────────────────────
+
+    @Test
+    @DisplayName("GET /actuator/health without token → 200")
+    void actuatorHealth_isPublic() {
+        webTestClient.get()
+                .uri("/actuator/health")
+                .exchange()
+                .expectStatus().isOk();
+    }
+}

--- a/cooking-session-service/src/test/resources/application-test.yml
+++ b/cooking-session-service/src/test/resources/application-test.yml
@@ -1,39 +1,33 @@
 spring:
+  cloud:
+    config:
+      enabled: false
+    discovery:
+      enabled: false
   datasource:
     url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL
     driver-class-name: org.h2.Driver
     username: sa
     password:
   jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
     hibernate:
       ddl-auto: create-drop
-    show-sql: false
     properties:
       hibernate:
         dialect: org.hibernate.dialect.H2Dialect
-  h2:
-    console:
-      enabled: true
-  cloud:
-    discovery:
-      enabled: false
-    config:
-      enabled: false
+  sql:
+    init:
+      mode: never
   security:
     oauth2:
       resourceserver:
         jwt:
           issuer-uri: http://localhost:9999/realms/test
 
-server:
-  port: 0
-
-management:
-  endpoints:
-    web:
-      exposure:
-        include: health
-
 eureka:
   client:
     enabled: false
+
+server:
+  port: 0

--- a/gateway-service/pom.xml
+++ b/gateway-service/pom.xml
@@ -32,6 +32,11 @@
             <artifactId>spring-boot-starter-oauth2-client</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
         </dependency>

--- a/gateway-service/src/main/java/com/cookmate/gateway/config/SecurityConfig.java
+++ b/gateway-service/src/main/java/com/cookmate/gateway/config/SecurityConfig.java
@@ -31,6 +31,9 @@ public class SecurityConfig {
                         .anyExchange().authenticated())
                 .oauth2Login(Customizer.withDefaults())
                 .oauth2Client(Customizer.withDefaults())
+                .oauth2ResourceServer(oauth2 -> oauth2
+                        .jwt(Customizer.withDefaults())
+                )
                 .exceptionHandling(exceptionHandling -> exceptionHandling
                         .authenticationEntryPoint(new HttpStatusServerEntryPoint(HttpStatus.UNAUTHORIZED))
                         .accessDeniedHandler(new HttpStatusServerAccessDeniedHandler(HttpStatus.FORBIDDEN))
@@ -56,4 +59,3 @@ public class SecurityConfig {
         return new CorsWebFilter(source);
     }
 }
-

--- a/gateway-service/src/test/java/com/cookmate/gateway/config/SecurityConfigTest.java
+++ b/gateway-service/src/test/java/com/cookmate/gateway/config/SecurityConfigTest.java
@@ -46,6 +46,16 @@ class SecurityConfigTest {
     }
 
     @Test
+    @DisplayName("GET /api/** with malformed Bearer token → 401")
+    void apiWithMalformedToken_returns401() {
+        webTestClient.get()
+                .uri("/api/recipes")
+                .header("Authorization", "Bearer invalid.malformed.token")
+                .exchange()
+                .expectStatus().isUnauthorized();
+    }
+
+    @Test
     @DisplayName("CORS preflight allows configured origin")
     void corsPreflightAllowsConfiguredOrigin() {
         webTestClient.options()

--- a/gateway-service/src/test/resources/application-test.yml
+++ b/gateway-service/src/test/resources/application-test.yml
@@ -22,6 +22,11 @@ spring:
             user-info-uri: http://localhost:9999/userinfo
             jwk-set-uri: http://localhost:9999/jwks
             user-name-attribute: sub
+      resourceserver:
+        jwt:
+          issuer-uri: http://localhost:9999/realms/test
+          jwk-set-uri: http://localhost:9999/jwks
+
 
 server:
   port: 0

--- a/implementation_plan.md
+++ b/implementation_plan.md
@@ -1,0 +1,289 @@
+# Konfiguracja mikroserwisów jako Spring Security Resource Servers
+
+## Opis problemu
+
+Mikroserwisy biznesowe (main-service, cooking-session-service, simulator-service) za API Gateway muszą działać jako OAuth2 Resource Servers — przyjmować tokeny JWT z nagłówka `Authorization`, weryfikować je kryptograficznie wobec Keycloak i egzekwować autoryzację na bazie ról (Claims).
+
+Aktualnie:
+- **Gateway** jest skonfigurowany jako OAuth2 Client (`oauth2Login` + `TokenRelay`) — to jest poprawne i nie zmieni się
+- **Mikroserwisy** nie mają żadnej konfiguracji bezpieczeństwa — są całkowicie otwarte
+- Keycloak definiuje role realm: `ROLE_USER`, `ROLE_ADMIN`
+- Role w JWT Keycloak znajdują się w claim `realm_access.roles`
+
+## Proponowane zmiany
+
+### 1. Scentralizowana konfiguracja JWT (config-repo)
+
+#### [MODIFY] [application.yml](file:///d:/repos/sumatywny/config-repo/application.yml)
+
+Dodanie wspólnej konfiguracji Resource Server do globalnego pliku `application.yml`, który jest ładowany przez wszystkie serwisy przez Config Server. Dzięki temu konfiguracja JWT jest w jednym miejscu.
+
+```yaml
+# Dodane na końcu istniejącej konfiguracji:
+spring:
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: ${KEYCLOAK_INTERNAL_URL:http://keycloak:8080}/realms/cookmate
+          jwk-set-uri: ${KEYCLOAK_INTERNAL_URL:http://keycloak:8080}/realms/cookmate/protocol/openid-connect/certs
+```
+
+> [!NOTE]
+> Gateway nadpisuje tę konfigurację swoim OAuth2 Client — nie koliduje to z Resource Server w pozostałych serwisach.
+
+---
+
+### 2. Zależności Maven
+
+#### [MODIFY] [pom.xml](file:///d:/repos/sumatywny/main-service/pom.xml) (main-service)
+#### [MODIFY] [pom.xml](file:///d:/repos/sumatywny/cooking-session-service/pom.xml) (cooking-session-service)
+#### [MODIFY] [pom.xml](file:///d:/repos/sumatywny/simulator-service/pom.xml) (simulator-service)
+
+Dodanie zależności do każdego serwisu biznesowego:
+
+```xml
+<dependency>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+</dependency>
+<dependency>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-security</artifactId>
+</dependency>
+```
+
+---
+
+### 3. Wspólna klasa konwertera ról Keycloak
+
+Keycloak umieszcza role realm w niestandardowym claimie `realm_access.roles`. Potrzebujemy `JwtAuthenticationConverter`, który je parsuje i tłumaczy na `GrantedAuthority`.
+
+> [!IMPORTANT]
+> Ponieważ projekt nie ma modułu `common` (każdy serwis ma osobny `spring-boot-starter-parent`), klasa `KeycloakJwtAuthenticationConverter` zostanie utworzona w każdym serwisie. Jednakże, żeby uniknąć powielania logiki, klasa jest identyczna we wszystkich serwisach — różni się jedynie pakietem.
+
+**Alternatywa**: Stworzyć moduł `common` Maven jako bibliotekę współdzieloną. Ale to wykracza poza scope tego issue i wymaga zmian w architekturze buildu.
+
+#### [NEW] `KeycloakJwtAuthenticationConverter.java` — w pakiecie `config` każdego serwisu
+
+```java
+@Component
+public class KeycloakJwtAuthenticationConverter implements Converter<Jwt, AbstractAuthenticationToken> {
+
+    @Override
+    public AbstractAuthenticationToken convert(Jwt jwt) {
+        Collection<GrantedAuthority> authorities = extractRealmRoles(jwt);
+        return new JwtAuthenticationToken(jwt, authorities, jwt.getClaimAsString("preferred_username"));
+    }
+
+    private Collection<GrantedAuthority> extractRealmRoles(Jwt jwt) {
+        Map<String, Object> realmAccess = jwt.getClaimAsMap("realm_access");
+        if (realmAccess == null || !realmAccess.containsKey("roles")) {
+            return Collections.emptyList();
+        }
+        @SuppressWarnings("unchecked")
+        Collection<String> roles = (Collection<String>) realmAccess.get("roles");
+        return roles.stream()
+                .map(role -> new SimpleGrantedAuthority("ROLE_" + role.replace("ROLE_", "")))
+                .collect(Collectors.toList());
+    }
+}
+```
+
+> [!NOTE]
+> Role Keycloak są zdefiniowane jako `ROLE_USER`, `ROLE_ADMIN`. Konwerter normalizuje je — zapewnia prefiks `ROLE_` (bez powielania) tak aby `hasRole('ROLE_USER')` działało poprawnie w Spring Security.
+
+---
+
+### 4. SecurityFilterChain — konfiguracja per serwis
+
+#### [NEW] `SecurityConfig.java` — main-service (`com.cookmate.main.config`)
+
+```java
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http,
+            KeycloakJwtAuthenticationConverter converter) throws Exception {
+        return http
+            .csrf(csrf -> csrf.disable())
+            .sessionManagement(session -> session.sessionCreationPolicy(STATELESS))
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/actuator/health", "/actuator/info").permitAll()
+                .anyRequest().authenticated()
+            )
+            .oauth2ResourceServer(oauth2 -> oauth2
+                .jwt(jwt -> jwt.jwtAuthenticationConverter(converter))
+            )
+            .exceptionHandling(ex -> ex
+                .authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED))
+                .accessDeniedHandler((req, res, accessDeniedException) -> {
+                    res.setStatus(HttpStatus.FORBIDDEN.value());
+                })
+            )
+            .build();
+    }
+}
+```
+
+#### [NEW] `SecurityConfig.java` — cooking-session-service (`com.cookmate.cookingsession.config`)
+
+Analogiczna konfiguracja, ale cooking-session-service używa WebFlux (ma `spring-boot-starter-webflux`), więc musi to być **reactive** security:
+
+```java
+@Configuration
+@EnableWebFluxSecurity
+@EnableReactiveMethodSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http,
+            ReactiveJwtAuthenticationConverterAdapter converter) throws Exception {
+        return http
+            .csrf(csrf -> csrf.disable())
+            .authorizeExchange(auth -> auth
+                .pathMatchers("/actuator/health", "/actuator/info").permitAll()
+                .anyExchange().authenticated()
+            )
+            .oauth2ResourceServer(oauth2 -> oauth2
+                .jwt(jwt -> jwt.jwtAuthenticationConverter(converter))
+            )
+            .exceptionHandling(ex -> ex
+                .authenticationEntryPoint(new HttpStatusServerEntryPoint(HttpStatus.UNAUTHORIZED))
+                .accessDeniedHandler(new HttpStatusServerAccessDeniedHandler(HttpStatus.FORBIDDEN))
+            )
+            .build();
+    }
+}
+```
+
+#### [NEW] `SecurityConfig.java` — simulator-service (`com.cookmate.simulator.config`)
+
+Analogiczna do main-service (obie to serwisy MVC/Servlet).
+
+---
+
+### 5. Zabezpieczenie endpointów adnotacjami `@PreAuthorize`
+
+#### [MODIFY] [RecipeController.java](file:///d:/repos/sumatywny/main-service/src/main/java/com/cookmate/main/controller/RecipeController.java)
+
+| Metoda | Reguła |
+|--------|--------|
+| `GET /api/recipes` | `authenticated` (przez SecurityFilterChain) |
+| `GET /api/recipes/{id}` | `authenticated` |
+| `POST /api/recipes` | `@PreAuthorize("hasRole('ROLE_USER')")` |
+| `PUT /api/recipes/{id}` | `@PreAuthorize("hasRole('ROLE_USER')")` |
+| `DELETE /api/recipes/{id}` | `@PreAuthorize("hasRole('ROLE_ADMIN')")` |
+
+#### [MODIFY] [StepController.java](file:///d:/repos/sumatywny/main-service/src/main/java/com/cookmate/main/controller/StepController.java)
+
+| Metoda | Reguła |
+|--------|--------|
+| `GET /api/steps/{stepId}` | `authenticated` |
+| `POST /api/steps/generate` | `@PreAuthorize("hasRole('ROLE_USER')")` |
+
+#### [MODIFY] [SimulatorController.java](file:///d:/repos/sumatywny/simulator-service/src/main/java/com/cookmate/simulator/controller/SimulatorController.java)
+
+| Metoda | Reguła |
+|--------|--------|
+| `POST /api/simulator/sessions/start` | `@PreAuthorize("hasRole('ROLE_USER')")` |
+| Pozostałe endpointy | `authenticated` (przez SecurityFilterChain) |
+
+#### [MODIFY] [CookingSessionController.java](file:///d:/repos/sumatywny/cooking-session-service/src/main/java/com/cookmate/cookingsession/controller/CookingSessionController.java)
+
+| Metoda | Reguła |
+|--------|--------|
+| `POST /api/cooking-sessions/progress` | `@PreAuthorize("hasRole('ROLE_USER')")` |
+| Pozostałe endpointy | `authenticated` (przez SecurityFilterChain) |
+
+---
+
+### 6. Aktualizacja konfiguracji testowej
+
+#### [MODIFY] [application-test.yml](file:///d:/repos/sumatywny/main-service/src/test/resources/application-test.yml) (main-service)
+
+Dodanie wyłączenia Resource Server w testach (testy nie mają dostępu do Keycloak):
+
+```yaml
+spring:
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: http://localhost:9999/realms/test
+```
+
+Plus dodanie `spring-security-test` dependency i ewentualne użycie `@WithMockUser` lub `@MockBean JwtDecoder` w testach.
+
+#### [MODIFY] [pom.xml](file:///d:/repos/sumatywny/main-service/pom.xml) — dodanie `spring-security-test`
+
+```xml
+<dependency>
+    <groupId>org.springframework.security</groupId>
+    <artifactId>spring-security-test</artifactId>
+    <scope>test</scope>
+</dependency>
+```
+
+Analogicznie dla cooking-session-service i simulator-service.
+
+---
+
+### 7. Gateway — dodanie resource-server do weryfikacji JWT
+
+#### [MODIFY] [pom.xml](file:///d:/repos/sumatywny/gateway-service/pom.xml)
+
+Dodanie `spring-boot-starter-oauth2-resource-server` aby gateway mógł weryfikować JWT i egzekwować role na poziomie routingu.
+
+#### [MODIFY] [SecurityConfig.java](file:///d:/repos/sumatywny/gateway-service/src/main/java/com/cookmate/gateway/config/SecurityConfig.java)
+
+Dodanie `.oauth2ResourceServer()` do istniejącej konfiguracji, co pozwoli na obsługę zarówno sesji (OAuth2 Login) jak i Bearer tokenów:
+
+```java
+.oauth2ResourceServer(oauth2 -> oauth2
+    .jwt(Customizer.withDefaults())
+)
+```
+
+#### [MODIFY] [gateway-service.yml](file:///d:/repos/sumatywny/config-repo/gateway-service.yml)
+
+Dodanie konfiguracji Resource Server JWT:
+
+```yaml
+spring:
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: ${KEYCLOAK_INTERNAL_URL:http://keycloak:8080}/realms/cookmate
+          jwk-set-uri: ${KEYCLOAK_INTERNAL_URL:http://keycloak:8080}/realms/cookmate/protocol/openid-connect/certs
+```
+
+---
+
+## Open Questions
+
+> [!IMPORTANT]
+> **Moduł common vs duplikacja**: Konwerter ról Keycloak (`KeycloakJwtAuthenticationConverter`) będzie zduplikowany w 3 serwisach (main, cooking-session, simulator). Czy wolisz żebym stworzył moduł `common` Maven, czy akceptujesz duplikację w ramach tego issue?
+
+> [!IMPORTANT]
+> **Reguły autoryzacji endpointów**: Zaproponowałem rozsądne reguły (GET = authenticated, POST/PUT = ROLE_USER, DELETE = ROLE_ADMIN). Czy te reguły są właściwe dla Twojego projektu, czy masz inne wymagania?
+
+> [!IMPORTANT]
+> **DiscoveryController (`/api/v1/discovery/*`)**: Ten kontroler pobiera dane z TheMealDB. Czy powinien być chroniony (authenticated), czy publicznie dostępny?
+
+## Plan weryfikacji
+
+### Testy automatyczne
+- Istniejące testy kontrolerów zostaną zaktualizowane o `@WithMockUser` / `@WithMockJwtUser` oraz `spring-security-test`
+- Testy SecurityConfig dla gateway (istniejące) zostaną zaktualizowane
+
+### Weryfikacja manualna
+- Po uruchomieniu Docker Compose:
+  - Żądanie bez tokenu → **401 Unauthorized**
+  - Żądanie z nieprawidłowym tokenem → **401 Unauthorized**
+  - Żądanie z poprawnym tokenem bez wymaganej roli → **403 Forbidden**
+  - Żądanie z poprawnym tokenem i rolą → **200 OK**

--- a/insomnia/recipes_test.yaml
+++ b/insomnia/recipes_test.yaml
@@ -1,0 +1,100 @@
+type: collection.insomnia.rest/5.0
+schema_version: "5.1"
+name: My first collection
+meta:
+  id: wrk_916414481f0e4fa29acb641d63e3e2b2
+  created: 1780552224598
+  modified: 1780552224598
+  description: ""
+collection:
+  - url: http://localhost:8085/api/recipes
+    name: recipes
+    meta:
+      id: req_f994a7c6624545e2aa030eb650d40720
+      created: 1780552224619
+      modified: 1780606278333
+      isPrivate: false
+      description: ""
+      sortKey: -1780552224619
+    method: GET
+    headers:
+      - name: User-Agent
+        value: insomnia/12.6.0
+        description: ""
+        disabled: false
+    authentication:
+      type: bearer
+      disabled: false
+      token: eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJoc1k1ZXRhT2xSOFoyaDFETXJ6Q0JSWmlBUElSR0JIY3lIX3JVMVlkR2xNIn0.eyJleHAiOjE3ODA2MDY1NzEsImlhdCI6MTc4MDYwNjI3MSwianRpIjoiZWEwYzQ4OGUtYTQ0YS00ZTE2LTg4YjYtMmUzYzRjYmQyN2YyIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy9jb29rbWF0ZSIsInN1YiI6IjM5YjhhZGU5LWIyNDUtNDJlZC04NjQyLTMzN2ZlMTE5ZDJhNiIsInR5cCI6IkJlYXJlciIsImF6cCI6ImNvb2ttYXRlLWNsaWVudCIsInNpZCI6ImIwMzRhMTIwLTFiNzYtNDRkZC1hNzQ5LTM5YTdkNTkzYTIwYiIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovL2xvY2FsaG9zdDo4MDgzIiwiaHR0cDovL2xvY2FsaG9zdDo4MDgxIiwiaHR0cDovL2xvY2FsaG9zdDo1MTczIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJST0xFX1VTRVIiLCJST0xFX0FETUlOIl19LCJzY29wZSI6ImVtYWlsIHByb2ZpbGUiLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwibmFtZSI6IlRlc3QgVXNlciIsInByZWZlcnJlZF91c2VybmFtZSI6InRlc3QudXNlciIsImdpdmVuX25hbWUiOiJUZXN0IiwiZmFtaWx5X25hbWUiOiJVc2VyIiwiZW1haWwiOiJ0ZXN0LnVzZXJAY29va21hdGUubG9jYWwifQ.SAj9Aiul5yTFiXPIeQW1_lQZGL5WbjIP18t9WSIrNKD6s1LsrNvhQ9WEq1zDBJr45pAlWDuDxGSMF1LvSV4NIYHlT8XrJ26vWV_O6khVTLqnZL8IFonUV7YM1Z2h9nUbLw_yPEz60D4LQuPo5tJQZ1C8wBgMEclhP4g88ndvX2vXPXy2NTo-h1NqyxqWtkXNikZEChPYaUcqirrJ23BTUtvuDdzmAv3PFu7h0syVRoH1KN9oKBeeuRsmsTLoexNC_dOMdFnHHgi0GWyJ2pWkdjtNARn3cRkQ66Rqy-r9tEVwlpvRmC7g3OlhnfBC7xHxxobN26Mel-ZPezwHHo-tDQ
+      prefix: ""
+    settings:
+      renderRequestBody: true
+      encodeUrl: true
+      followRedirects: global
+      cookies:
+        send: true
+        store: true
+      rebuildPath: true
+  - url: http://localhost:8080/realms/cookmate/protocol/openid-connect/token
+    name: token
+    meta:
+      id: req_536dec40d2ad42eb9cea9f0f4c66232d
+      created: 1780552634468
+      modified: 1780606308125
+      isPrivate: false
+      description: ""
+      sortKey: -1780552634468
+    method: POST
+    body:
+      mimeType: application/x-www-form-urlencoded
+      params:
+        - name: client_id
+          value: cookmate-client
+          description: ""
+          disabled: false
+        - name: client_secret
+          value: cookmate-secret
+          description: ""
+          disabled: false
+        - name: username
+          value: test.user
+          description: ""
+          disabled: false
+        - name: password
+          value: test12345
+          description: ""
+          disabled: false
+        - name: grant_type
+          value: password
+          description: ""
+          disabled: false
+    headers:
+      - name: Content-Type
+        value: application/x-www-form-urlencoded
+      - name: User-Agent
+        value: insomnia/12.6.0
+        description: ""
+        disabled: false
+    authentication:
+      type: none
+    settings:
+      renderRequestBody: true
+      encodeUrl: true
+      followRedirects: global
+      cookies:
+        send: true
+        store: true
+      rebuildPath: true
+cookieJar:
+  name: Default Jar
+  meta:
+    id: jar_871907c20f900e3501749382212895245be4e38a
+    created: 1780552224610
+    modified: 1780552224610
+environments:
+  name: Base Environment
+  meta:
+    id: env_871907c20f900e3501749382212895245be4e38a
+    created: 1780552224608
+    modified: 1780552224608
+    isPrivate: false

--- a/keycloak/realm-export.json
+++ b/keycloak/realm-export.json
@@ -40,7 +40,7 @@
       "bearerOnly": false,
       "standardFlowEnabled": true,
       "implicitFlowEnabled": false,
-      "directAccessGrantsEnabled": false,
+      "directAccessGrantsEnabled": true,
       "serviceAccountsEnabled": false,
       "clientAuthenticatorType": "client-secret",
       "secret": "cookmate-secret",

--- a/main-service/pom.xml
+++ b/main-service/pom.xml
@@ -53,6 +53,16 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
 
+        <!-- OAuth2 Resource Server (JWT validation) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
@@ -89,6 +99,12 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>

--- a/main-service/src/main/java/com/cookmate/main/config/KeycloakJwtAuthenticationConverter.java
+++ b/main-service/src/main/java/com/cookmate/main/config/KeycloakJwtAuthenticationConverter.java
@@ -1,0 +1,59 @@
+package com.cookmate.main.config;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Converts Keycloak JWT tokens into Spring Security authentication tokens.
+ * <p>
+ * Keycloak stores realm roles under the {@code realm_access.roles} claim.
+ * This converter extracts those roles and maps them to Spring Security
+ * {@link GrantedAuthority} instances with the {@code ROLE_} prefix.
+ */
+@Component
+public class KeycloakJwtAuthenticationConverter implements Converter<Jwt, AbstractAuthenticationToken> {
+
+    private static final String REALM_ACCESS_CLAIM = "realm_access";
+    private static final String ROLES_KEY = "roles";
+    private static final String ROLE_PREFIX = "ROLE_";
+
+    @Override
+    public AbstractAuthenticationToken convert(Jwt jwt) {
+        Collection<GrantedAuthority> authorities = extractRealmRoles(jwt);
+        return new JwtAuthenticationToken(jwt, authorities, jwt.getClaimAsString("preferred_username"));
+    }
+
+    private Collection<GrantedAuthority> extractRealmRoles(Jwt jwt) {
+        Map<String, Object> realmAccess = jwt.getClaimAsMap(REALM_ACCESS_CLAIM);
+        if (realmAccess == null || !realmAccess.containsKey(ROLES_KEY)) {
+            return Collections.emptyList();
+        }
+
+        @SuppressWarnings("unchecked")
+        List<String> roles = (List<String>) realmAccess.get(ROLES_KEY);
+
+        return roles.stream()
+                .map(this::toGrantedAuthority)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Ensures each role has exactly one ROLE_ prefix, regardless of whether
+     * Keycloak defines them with or without the prefix.
+     */
+    private GrantedAuthority toGrantedAuthority(String role) {
+        String normalizedRole = role.startsWith(ROLE_PREFIX) ? role : ROLE_PREFIX + role;
+        return new SimpleGrantedAuthority(normalizedRole);
+    }
+}

--- a/main-service/src/main/java/com/cookmate/main/config/SecurityConfig.java
+++ b/main-service/src/main/java/com/cookmate/main/config/SecurityConfig.java
@@ -1,0 +1,46 @@
+package com.cookmate.main.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
+
+/**
+ * Security configuration for main-service acting as an OAuth2 Resource Server.
+ * <p>
+ * All API endpoints require authentication via a valid JWT token.
+ * Fine-grained role-based access is enforced at the method level using {@code @PreAuthorize}.
+ * Actuator health and info endpoints are publicly accessible for monitoring.
+ */
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http,
+                                                   KeycloakJwtAuthenticationConverter jwtAuthenticationConverter) throws Exception {
+        return http
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/actuator/health", "/actuator/info").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .oauth2ResourceServer(oauth2 -> oauth2
+                        .jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter))
+                )
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED))
+                        .accessDeniedHandler((request, response, accessDeniedException) ->
+                                response.setStatus(HttpStatus.FORBIDDEN.value())
+                        )
+                )
+                .build();
+    }
+}

--- a/main-service/src/main/java/com/cookmate/main/controller/RecipeController.java
+++ b/main-service/src/main/java/com/cookmate/main/controller/RecipeController.java
@@ -13,6 +13,7 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -108,6 +109,7 @@ public class RecipeController {
      * @return created recipe
      */
     @PostMapping
+    @PreAuthorize("hasRole('ROLE_USER')")
     public ResponseEntity<Recipe> create(@Valid @RequestBody RecipeCreateRequest request) {
         Recipe saved = recipeService.save(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(saved);
@@ -121,6 +123,7 @@ public class RecipeController {
      * @return updated recipe
      */
     @PutMapping("/{id}")
+    @PreAuthorize("hasRole('ROLE_USER')")
     public ResponseEntity<Recipe> update(
         @PathVariable Long id,
         @Valid @RequestBody RecipeUpdateRequest request) {
@@ -141,6 +144,7 @@ public class RecipeController {
      * @return no content if successful
      */
     @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public ResponseEntity<Void> delete(@PathVariable Long id) {
         recipeService.deleteByIdOrThrow(id);
         return ResponseEntity.noContent().build();

--- a/main-service/src/main/java/com/cookmate/main/controller/StepController.java
+++ b/main-service/src/main/java/com/cookmate/main/controller/StepController.java
@@ -7,6 +7,7 @@ import com.cookmate.main.service.StepService;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -33,6 +34,7 @@ public class StepController {
      * @return response z listą kroków
      */
     @PostMapping("/generate")
+    @PreAuthorize("hasRole('ROLE_USER')")
     public ResponseEntity<StepGenerationResponse> generateSteps(
             @Valid @RequestBody StepGenerationRequest request,
             HttpSession session) {

--- a/main-service/src/main/java/com/cookmate/main/exception/GlobalExceptionHandler.java
+++ b/main-service/src/main/java/com/cookmate/main/exception/GlobalExceptionHandler.java
@@ -15,6 +15,8 @@ import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authorization.AuthorizationDeniedException;
 
 import java.time.Instant;
 import java.util.List;
@@ -191,7 +193,11 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ApiErrorResponse> handleUnexpectedException(Exception ex, HttpServletRequest request) {
+    public ResponseEntity<ApiErrorResponse> handleUnexpectedException(Exception ex, HttpServletRequest request) throws Exception {
+        if (ex instanceof AccessDeniedException || ex instanceof AuthorizationDeniedException) {
+            throw ex;
+        }
+
         Throwable rootCause = ex;
         while (rootCause.getCause() != null && rootCause.getCause() != rootCause) {
             rootCause = rootCause.getCause();

--- a/main-service/src/test/java/com/cookmate/main/config/SecurityFilterTest.java
+++ b/main-service/src/test/java/com/cookmate/main/config/SecurityFilterTest.java
@@ -1,0 +1,102 @@
+package com.cookmate.main.config;
+
+import com.cookmate.main.service.MealDbClient;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Security filter tests for main-service.
+ * Verifies that:
+ * - Requests without a JWT token return 401 Unauthorized
+ * - Requests with insufficient roles return 403 Forbidden
+ * - Public endpoints (actuator) are accessible without authentication
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@DisplayName("main-service — Security Filter Tests")
+class SecurityFilterTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private JwtDecoder jwtDecoder;
+
+    @MockitoBean
+    private MealDbClient mealDbClient;
+
+    // ─── 401 Unauthorized (no token) ───────────────────────────
+
+    @Test
+    @DisplayName("GET /api/recipes without token → 401")
+    void getRecipes_withoutToken_returns401() throws Exception {
+        mockMvc.perform(get("/api/recipes"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("POST /api/recipes without token → 401")
+    void postRecipe_withoutToken_returns401() throws Exception {
+        mockMvc.perform(post("/api/recipes")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"name":"Test","description":"d","ingredients":"i","instructions":"x","preparationTimeMinutes":10}
+                                """))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("DELETE /api/recipes/1 without token → 401")
+    void deleteRecipe_withoutToken_returns401() throws Exception {
+        mockMvc.perform(delete("/api/recipes/{id}", 1L))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("POST /api/steps/generate without token → 401")
+    void generateSteps_withoutToken_returns401() throws Exception {
+        mockMvc.perform(post("/api/steps/generate")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"mealId":"52772"}
+                                """))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ─── 403 Forbidden (wrong role) ────────────────────────────
+
+    @Test
+    @DisplayName("DELETE /api/recipes/1 as ROLE_USER (not ADMIN) → 403")
+    void deleteRecipe_asUser_returns403() throws Exception {
+        mockMvc.perform(delete("/api/recipes/{id}", 1L)
+                        .with(jwt().authorities(List.of(
+                                new SimpleGrantedAuthority("ROLE_USER")
+                        ))))
+                .andExpect(status().isForbidden());
+    }
+
+    // ─── Public endpoints ──────────────────────────────────────
+
+    @Test
+    @DisplayName("GET /actuator/health without token → 200")
+    void actuatorHealth_isPublic() throws Exception {
+        mockMvc.perform(get("/actuator/health"))
+                .andExpect(status().isOk());
+    }
+}

--- a/main-service/src/test/java/com/cookmate/main/controller/DiscoveryControllerTest.java
+++ b/main-service/src/test/java/com/cookmate/main/controller/DiscoveryControllerTest.java
@@ -10,6 +10,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -18,6 +20,7 @@ import reactor.core.publisher.Mono;
 
 import java.util.List;
 
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -31,8 +34,11 @@ class DiscoveryControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockitoBean // Nowy standard Spring 4
+    @MockitoBean
     private MealDbClient mealDbClient;
+
+    @MockitoBean
+    private JwtDecoder jwtDecoder;
 
     @Test
     void shouldReturnMealsWhenSearchingByName() throws Exception {
@@ -44,7 +50,8 @@ class DiscoveryControllerTest {
 
         // Obsługa asynchronicznego Mono w MockMvc
         MvcResult mvcResult = mockMvc.perform(get("/api/v1/discovery/search")
-                        .param("name", "Arrabiata"))
+                        .param("name", "Arrabiata")
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER"))))
                 .andExpect(request().asyncStarted())
                 .andReturn();
 
@@ -61,7 +68,8 @@ class DiscoveryControllerTest {
 
         when(mealDbClient.listFullCategories()).thenReturn(Mono.just(categoryResponse));
 
-        MvcResult mvcResult = mockMvc.perform(get("/api/v1/discovery/categories"))
+        MvcResult mvcResult = mockMvc.perform(get("/api/v1/discovery/categories")
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER"))))
                 .andExpect(request().asyncStarted())
                 .andReturn();
 
@@ -79,7 +87,8 @@ class DiscoveryControllerTest {
         when(mealDbClient.listAllBy("c")).thenReturn(Mono.just(listResponse));
 
         MvcResult mvcResult = mockMvc.perform(get("/api/v1/discovery/list")
-                        .param("type", "c"))
+                        .param("type", "c")
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER"))))
                 .andExpect(request().asyncStarted())
                 .andReturn();
 

--- a/main-service/src/test/java/com/cookmate/main/controller/RecipeControllerTest.java
+++ b/main-service/src/test/java/com/cookmate/main/controller/RecipeControllerTest.java
@@ -11,7 +11,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
-import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -27,12 +27,12 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import com.cookmate.main.service.MealDbClient;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
 @Transactional
-@WithMockUser(roles = "ROLE_USER")
 class RecipeControllerTest {
 
     @Autowired
@@ -56,6 +56,7 @@ class RecipeControllerTest {
         recipeRepository.save(new Recipe("Banana Bread", "Moist bread", "bananas, flour", "Mix and bake", 50));
 
         mockMvc.perform(get("/api/recipes")
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER")))
                         .param("page", "0")
                         .param("size", "10")
                         .contentType(MediaType.APPLICATION_JSON))
@@ -82,6 +83,7 @@ class RecipeControllerTest {
                 .recipeId(recipeId).durationMinutes(3).createdAt(LocalDateTime.now()).build());
 
         mockMvc.perform(get("/api/recipes/{recipeId}/steps", recipeId)
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER")))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -95,6 +97,7 @@ class RecipeControllerTest {
     @Test
     void shouldReturnEmptyListWhenNoStepsForRecipe() throws Exception {
         mockMvc.perform(get("/api/recipes/{recipeId}/steps", "recipe-with-no-steps")
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER")))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -105,6 +108,7 @@ class RecipeControllerTest {
     @Test
     void shouldReturn400WhenPageIsNegative() throws Exception {
         mockMvc.perform(get("/api/recipes")
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER")))
                         .param("page", "-1")
                         .param("size", "10"))
                 .andExpect(status().isBadRequest())
@@ -117,6 +121,7 @@ class RecipeControllerTest {
     @Test
     void shouldReturn400WhenSizeIsZero() throws Exception {
         mockMvc.perform(get("/api/recipes")
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER")))
                         .param("page", "0")
                         .param("size", "0"))
                 .andExpect(status().isBadRequest())
@@ -128,7 +133,8 @@ class RecipeControllerTest {
 
     @Test
     void shouldReturn404ContractForUnknownRecipe() throws Exception {
-        mockMvc.perform(get("/api/recipes/{id}", 999999L))
+        mockMvc.perform(get("/api/recipes/{id}", 999999L)
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER"))))
                 .andExpect(status().isNotFound())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.status").value(404))
@@ -153,6 +159,7 @@ class RecipeControllerTest {
                 """;
 
         mockMvc.perform(put("/api/recipes/{id}", 999999L)
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER")))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody))
                 .andExpect(status().isNotFound())
@@ -163,9 +170,9 @@ class RecipeControllerTest {
     }
 
     @Test
-    @WithMockUser(roles = "ROLE_ADMIN")
     void shouldReturn404ContractForUnknownRecipeOnDelete() throws Exception {
-        mockMvc.perform(delete("/api/recipes/{id}", 999999L))
+        mockMvc.perform(delete("/api/recipes/{id}", 999999L)
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_ADMIN"))))
                 .andExpect(status().isNotFound())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.code").value("RECIPE_NOT_FOUND"))
@@ -176,6 +183,7 @@ class RecipeControllerTest {
     @Test
     void shouldReturn400ForMalformedRequestBody() throws Exception {
         mockMvc.perform(post("/api/recipes")
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER")))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"name\":\"Soup\","))
                 .andExpect(status().isBadRequest())
@@ -188,6 +196,7 @@ class RecipeControllerTest {
     @Test
     void shouldReturn405WhenMethodIsNotSupported() throws Exception {
         mockMvc.perform(patch("/api/recipes")
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER")))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isMethodNotAllowed())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))

--- a/main-service/src/test/java/com/cookmate/main/controller/RecipeControllerTest.java
+++ b/main-service/src/test/java/com/cookmate/main/controller/RecipeControllerTest.java
@@ -10,6 +10,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -30,6 +32,7 @@ import com.cookmate.main.service.MealDbClient;
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
 @Transactional
+@WithMockUser(roles = "ROLE_USER")
 class RecipeControllerTest {
 
     @Autowired
@@ -43,6 +46,9 @@ class RecipeControllerTest {
 
     @MockitoBean
     private MealDbClient mealDbClient;
+
+    @MockitoBean
+    private JwtDecoder jwtDecoder;
 
     @Test
     void shouldReturnPaginatedRecipesWithMetadata() throws Exception {
@@ -157,6 +163,7 @@ class RecipeControllerTest {
     }
 
     @Test
+    @WithMockUser(roles = "ROLE_ADMIN")
     void shouldReturn404ContractForUnknownRecipeOnDelete() throws Exception {
         mockMvc.perform(delete("/api/recipes/{id}", 999999L))
                 .andExpect(status().isNotFound())

--- a/main-service/src/test/java/com/cookmate/main/controller/StepControllerTest.java
+++ b/main-service/src/test/java/com/cookmate/main/controller/StepControllerTest.java
@@ -8,7 +8,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,6 +19,7 @@ import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -30,6 +34,9 @@ class StepControllerTest {
 
     @Autowired
     private StepRepository stepRepository;
+
+    @MockitoBean
+    private JwtDecoder jwtDecoder;
 
     @Test
     void shouldReturnStepDtoForExistingStep() throws Exception {
@@ -47,6 +54,7 @@ class StepControllerTest {
             .build());
 
         mockMvc.perform(get("/api/steps/{stepId}", savedStep.getId())
+                .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER")))
                 .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -63,7 +71,8 @@ class StepControllerTest {
 
     @Test
     void shouldReturn404ForUnknownStep() throws Exception {
-        mockMvc.perform(get("/api/steps/{stepId}", 999999L))
+        mockMvc.perform(get("/api/steps/{stepId}", 999999L)
+                .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER"))))
             .andExpect(status().isNotFound())
             .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
             .andExpect(jsonPath("$.timestamp").exists())

--- a/main-service/src/test/resources/application-test.yml
+++ b/main-service/src/test/resources/application-test.yml
@@ -16,6 +16,11 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.H2Dialect
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: http://localhost:9999/realms/test
 eureka:
   client:
-    enabled: false   # Wyłącza klienta Eureka
+    enabled: false   # Wyłącza klienta Eureka

--- a/simulator-service/pom.xml
+++ b/simulator-service/pom.xml
@@ -88,12 +88,29 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
 
+        <!-- OAuth2 Resource Server (JWT validation) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+
+
         <!-- Test -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>

--- a/simulator-service/src/main/java/com/cookmate/simulator/config/KeycloakJwtAuthenticationConverter.java
+++ b/simulator-service/src/main/java/com/cookmate/simulator/config/KeycloakJwtAuthenticationConverter.java
@@ -1,0 +1,59 @@
+package com.cookmate.simulator.config;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Converts Keycloak JWT tokens into Spring Security authentication tokens.
+ * <p>
+ * Keycloak stores realm roles under the {@code realm_access.roles} claim.
+ * This converter extracts those roles and maps them to Spring Security
+ * {@link GrantedAuthority} instances with the {@code ROLE_} prefix.
+ */
+@Component
+public class KeycloakJwtAuthenticationConverter implements Converter<Jwt, AbstractAuthenticationToken> {
+
+    private static final String REALM_ACCESS_CLAIM = "realm_access";
+    private static final String ROLES_KEY = "roles";
+    private static final String ROLE_PREFIX = "ROLE_";
+
+    @Override
+    public AbstractAuthenticationToken convert(Jwt jwt) {
+        Collection<GrantedAuthority> authorities = extractRealmRoles(jwt);
+        return new JwtAuthenticationToken(jwt, authorities, jwt.getClaimAsString("preferred_username"));
+    }
+
+    private Collection<GrantedAuthority> extractRealmRoles(Jwt jwt) {
+        Map<String, Object> realmAccess = jwt.getClaimAsMap(REALM_ACCESS_CLAIM);
+        if (realmAccess == null || !realmAccess.containsKey(ROLES_KEY)) {
+            return Collections.emptyList();
+        }
+
+        @SuppressWarnings("unchecked")
+        List<String> roles = (List<String>) realmAccess.get(ROLES_KEY);
+
+        return roles.stream()
+                .map(this::toGrantedAuthority)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Ensures each role has exactly one ROLE_ prefix, regardless of whether
+     * Keycloak defines them with or without the prefix.
+     */
+    private GrantedAuthority toGrantedAuthority(String role) {
+        String normalizedRole = role.startsWith(ROLE_PREFIX) ? role : ROLE_PREFIX + role;
+        return new SimpleGrantedAuthority(normalizedRole);
+    }
+}

--- a/simulator-service/src/main/java/com/cookmate/simulator/config/SecurityConfig.java
+++ b/simulator-service/src/main/java/com/cookmate/simulator/config/SecurityConfig.java
@@ -1,0 +1,47 @@
+package com.cookmate.simulator.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
+
+/**
+ * Security configuration for simulator-service acting as an OAuth2 Resource Server.
+ * <p>
+ * All API endpoints require authentication via a valid JWT token.
+ * Fine-grained role-based access is enforced at the method level using {@code @PreAuthorize}.
+ * Actuator health and info endpoints are publicly accessible for monitoring.
+ */
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http,
+                                                   KeycloakJwtAuthenticationConverter jwtAuthenticationConverter) throws Exception {
+        return http
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/actuator/health", "/actuator/info").permitAll()
+                        .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .oauth2ResourceServer(oauth2 -> oauth2
+                        .jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter))
+                )
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED))
+                        .accessDeniedHandler((request, response, accessDeniedException) ->
+                                response.setStatus(HttpStatus.FORBIDDEN.value())
+                        )
+                )
+                .build();
+    }
+}

--- a/simulator-service/src/main/java/com/cookmate/simulator/controller/SimulatorController.java
+++ b/simulator-service/src/main/java/com/cookmate/simulator/controller/SimulatorController.java
@@ -47,6 +47,7 @@ public class SimulatorController {
     }
 
     @PostMapping("/sessions/{sessionId}/step")
+    @PreAuthorize("hasRole('ROLE_USER')")
     @Operation(summary = "Execute specific step", description = "Fallback endpoint to execute a specific step payload.")
     @ApiResponse(responseCode = "200", description = "Step execution result", content = @Content(schema = @Schema(implementation = StepExecutionResultDto.class)))
     public ResponseEntity<StepExecutionResultDto> receiveStep(
@@ -57,6 +58,7 @@ public class SimulatorController {
     }
 
     @PostMapping("/sessions/{sessionId}/steps/execute")
+    @PreAuthorize("hasRole('ROLE_USER')")
     @Operation(summary = "Execute next step", description = "One-click endpoint to execute the next pending step in the session.")
     @ApiResponse(responseCode = "200", description = "Step execution result", content = @Content(schema = @Schema(implementation = StepExecutionResultDto.class)))
     public ResponseEntity<StepExecutionResultDto> executeNextStep(@PathVariable String sessionId) {
@@ -64,6 +66,7 @@ public class SimulatorController {
     }
 
     @PostMapping("/sessions/{sessionId}/rewind")
+    @PreAuthorize("hasRole('ROLE_USER')")
     @Operation(summary = "Rewind session", description = "Moves session progress back to the given step number.")
     @ApiResponse(responseCode = "200", description = "Session rewound", content = @Content(schema = @Schema(implementation = SimulationStatusResponseDto.class)))
     public ResponseEntity<SimulationStatusResponseDto> rewindToStep(
@@ -89,6 +92,7 @@ public class SimulatorController {
     }
 
     @PostMapping("/sessions/{sessionId}/complete")
+    @PreAuthorize("hasRole('ROLE_USER')")
     @Operation(summary = "Complete session manually", description = "Marks session as completed and notifies cooking-session-service.")
     public ResponseEntity<Void> completeSession(@PathVariable String sessionId) {
         simulationService.completeSession(sessionId);

--- a/simulator-service/src/main/java/com/cookmate/simulator/controller/SimulatorController.java
+++ b/simulator-service/src/main/java/com/cookmate/simulator/controller/SimulatorController.java
@@ -17,6 +17,7 @@ import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -38,6 +39,7 @@ public class SimulatorController {
     private final SimulationService simulationService;
 
     @PostMapping("/sessions/start")
+    @PreAuthorize("hasRole('ROLE_USER')")
     @Operation(summary = "Start simulation session", description = "Creates a new session and loads recipe steps from main-service.")
     @ApiResponse(responseCode = "201", description = "Session started", content = @Content(schema = @Schema(implementation = SimulationStatusResponseDto.class)))
     public ResponseEntity<SimulationStatusResponseDto> startSimulation(@Valid @RequestBody StartSimulationRequestDto request) {

--- a/simulator-service/src/test/java/com/cookmate/simulator/config/SecurityFilterTest.java
+++ b/simulator-service/src/test/java/com/cookmate/simulator/config/SecurityFilterTest.java
@@ -1,0 +1,86 @@
+package com.cookmate.simulator.config;
+
+import com.cookmate.simulator.client.CookingSessionClient;
+import com.cookmate.simulator.client.MainServiceClient;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Security filter tests for simulator-service.
+ * Verifies that:
+ * - Requests without a JWT token return 401 Unauthorized
+ * - Public endpoints (actuator, swagger) are accessible without authentication
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@DisplayName("simulator-service — Security Filter Tests")
+class SecurityFilterTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private JwtDecoder jwtDecoder;
+
+    @MockitoBean
+    private MainServiceClient mainServiceClient;
+
+    @MockitoBean
+    private CookingSessionClient cookingSessionClient;
+
+    // ─── 401 Unauthorized (no token) ───────────────────────────
+
+    @Test
+    @DisplayName("POST /api/simulator/sessions/start without token → 401")
+    void startSession_withoutToken_returns401() throws Exception {
+        mockMvc.perform(post("/api/simulator/sessions/start")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"recipeId":"52772"}
+                                """))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("GET /api/simulator/sessions/xyz/status without token → 401")
+    void getStatus_withoutToken_returns401() throws Exception {
+        mockMvc.perform(get("/api/simulator/sessions/xyz/status"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("POST /api/simulator/sessions/xyz/steps/execute without token → 401")
+    void executeStep_withoutToken_returns401() throws Exception {
+        mockMvc.perform(post("/api/simulator/sessions/xyz/steps/execute"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ─── Public endpoints ──────────────────────────────────────
+
+    @Test
+    @DisplayName("GET /actuator/health without token → 200")
+    void actuatorHealth_isPublic() throws Exception {
+        mockMvc.perform(get("/actuator/health"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("GET /swagger-ui.html without token → accessible")
+    void swaggerUi_isPublic() throws Exception {
+        mockMvc.perform(get("/swagger-ui.html"))
+                .andExpect(status().is3xxRedirection());
+    }
+}

--- a/simulator-service/src/test/java/com/cookmate/simulator/controller/SimulationControllerIntegrationTest.java
+++ b/simulator-service/src/test/java/com/cookmate/simulator/controller/SimulationControllerIntegrationTest.java
@@ -11,6 +11,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -18,6 +20,7 @@ import org.springframework.test.web.servlet.MvcResult;
 
 import java.util.List;
 
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.hamcrest.Matchers.*;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -44,6 +47,9 @@ class SimulationControllerIntegrationTest {
     @MockitoBean
     private CookingSessionClient cookingSessionClient;
 
+    @MockitoBean
+    private JwtDecoder jwtDecoder;
+
     @BeforeEach
     void cleanDb() {
         stepRepo.deleteAll();
@@ -58,6 +64,7 @@ class SimulationControllerIntegrationTest {
         mockMainSteps("52772");
 
         mockMvc.perform(post("/api/simulator/sessions/start")
+                .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER")))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"recipeId\":\"52772\"}"))
             .andExpect(status().isCreated())
@@ -71,6 +78,7 @@ class SimulationControllerIntegrationTest {
     @DisplayName("POST /sessions/start — 400 gdy brak recipeId")
     void startSimulation_returns400WhenNoRecipeId() throws Exception {
         mockMvc.perform(post("/api/simulator/sessions/start")
+                .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER")))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"recipeId\":\"\"}"))
             .andExpect(status().isBadRequest());
@@ -83,6 +91,7 @@ class SimulationControllerIntegrationTest {
             .thenThrow(new RuntimeException("Connection refused"));
 
         mockMvc.perform(post("/api/simulator/sessions/start")
+                .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER")))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"recipeId\":\"52772\"}"))
             .andExpect(status().isServiceUnavailable())
@@ -96,7 +105,8 @@ class SimulationControllerIntegrationTest {
     void executeNextStep_returns200() throws Exception {
         String sessionId = createSession("52772");
 
-        mockMvc.perform(post("/api/simulator/sessions/" + sessionId + "/steps/execute"))
+        mockMvc.perform(post("/api/simulator/sessions/" + sessionId + "/steps/execute")
+                .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER"))))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.success").value(true))
             .andExpect(jsonPath("$.stepNumber").value(1));
@@ -105,7 +115,8 @@ class SimulationControllerIntegrationTest {
     @Test
     @DisplayName("POST /sessions/{id}/steps/execute — 404 dla nieistniejącej sesji")
     void executeNextStep_returns404() throws Exception {
-        mockMvc.perform(post("/api/simulator/sessions/nonexistent/steps/execute"))
+        mockMvc.perform(post("/api/simulator/sessions/nonexistent/steps/execute")
+                .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER"))))
             .andExpect(status().isNotFound())
             .andExpect(jsonPath("$.code").value("SIMULATION_NOT_FOUND"));
     }
@@ -121,6 +132,7 @@ class SimulationControllerIntegrationTest {
             """;
 
         mockMvc.perform(post("/api/simulator/sessions/" + sessionId + "/step")
+                .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER")))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(body))
             .andExpect(status().isOk())
@@ -133,6 +145,7 @@ class SimulationControllerIntegrationTest {
         String sessionId = createSession("52772");
 
         mockMvc.perform(post("/api/simulator/sessions/" + sessionId + "/step")
+                .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER")))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"stepNumber\":null}"))
             .andExpect(status().isBadRequest());
@@ -145,7 +158,8 @@ class SimulationControllerIntegrationTest {
     void getStatus_returns200() throws Exception {
         String sessionId = createSession("52772");
 
-        mockMvc.perform(get("/api/simulator/sessions/" + sessionId + "/status"))
+        mockMvc.perform(get("/api/simulator/sessions/" + sessionId + "/status")
+                .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER"))))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.sessionId").value(sessionId))
             .andExpect(jsonPath("$.status").value("RUNNING"));
@@ -154,7 +168,8 @@ class SimulationControllerIntegrationTest {
     @Test
     @DisplayName("GET /sessions/{id}/status — 404 dla nieistniejącej sesji")
     void getStatus_returns404() throws Exception {
-        mockMvc.perform(get("/api/simulator/sessions/fake/status"))
+        mockMvc.perform(get("/api/simulator/sessions/fake/status")
+                .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER"))))
             .andExpect(status().isNotFound());
     }
 
@@ -165,7 +180,8 @@ class SimulationControllerIntegrationTest {
     void getHistory_returns200() throws Exception {
         String sessionId = createSession("52772");
 
-        mockMvc.perform(get("/api/simulator/sessions/" + sessionId + "/history"))
+        mockMvc.perform(get("/api/simulator/sessions/" + sessionId + "/history")
+                .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER"))))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$", hasSize(2)))
             .andExpect(jsonPath("$[0].status").value("PENDING"));
@@ -178,9 +194,11 @@ class SimulationControllerIntegrationTest {
     void rewind_returns200() throws Exception {
         String sessionId = createSession("52772");
         // Najpierw wykonaj krok
-        mockMvc.perform(post("/api/simulator/sessions/" + sessionId + "/steps/execute"));
+        mockMvc.perform(post("/api/simulator/sessions/" + sessionId + "/steps/execute")
+                .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER"))));
 
-        mockMvc.perform(post("/api/simulator/sessions/" + sessionId + "/rewind?stepNumber=0"))
+        mockMvc.perform(post("/api/simulator/sessions/" + sessionId + "/rewind?stepNumber=0")
+                .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER"))))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.currentStep").value(0))
             .andExpect(jsonPath("$.status").value("RUNNING"));
@@ -198,6 +216,7 @@ class SimulationControllerIntegrationTest {
     private String createSession(String recipeId) throws Exception {
         mockMainSteps(recipeId);
         MvcResult result = mockMvc.perform(post("/api/simulator/sessions/start")
+                .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER")))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"recipeId\":\"" + recipeId + "\"}"))
             .andExpect(status().isCreated())

--- a/simulator-service/src/test/java/com/cookmate/simulator/integration/GuidedCookingFlowTest.java
+++ b/simulator-service/src/test/java/com/cookmate/simulator/integration/GuidedCookingFlowTest.java
@@ -23,6 +23,8 @@ import static org.hamcrest.Matchers.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 /**
  * End-to-end flow test dla guided cooking:
@@ -65,6 +67,7 @@ class GuidedCookingFlowTest {
 
         // === 1. START — utwórz sesję ===
         MvcResult startResult = mockMvc.perform(post("/api/simulator/sessions/start")
+                .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER")))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"recipeId\":\"52772\"}"))
             .andExpect(status().isCreated())
@@ -77,7 +80,8 @@ class GuidedCookingFlowTest {
         verify(mainServiceClient).getRecipeSteps("52772");
 
         // === 2. STATUS — sprawdź stan przed wykonaniem ===
-        mockMvc.perform(get("/api/simulator/sessions/" + sessionId + "/status"))
+        mockMvc.perform(get("/api/simulator/sessions/" + sessionId + "/status")
+                .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER"))))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.status").value("RUNNING"))
             .andExpect(jsonPath("$.currentStep").value(0))
@@ -85,26 +89,30 @@ class GuidedCookingFlowTest {
             .andExpect(jsonPath("$.history[1].status").value("PENDING"));
 
         // === 3. EXECUTE STEP 1 ===
-        mockMvc.perform(post("/api/simulator/sessions/" + sessionId + "/steps/execute"))
+        mockMvc.perform(post("/api/simulator/sessions/" + sessionId + "/steps/execute")
+                .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER"))))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.success").value(true))
             .andExpect(jsonPath("$.stepNumber").value(1));
 
         // === 4. STATUS po kroku 1 — sprawdź postęp ===
-        mockMvc.perform(get("/api/simulator/sessions/" + sessionId + "/status"))
+        mockMvc.perform(get("/api/simulator/sessions/" + sessionId + "/status")
+                .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER"))))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.currentStep").value(1))
             .andExpect(jsonPath("$.history[0].status").value("EXECUTED"))
             .andExpect(jsonPath("$.history[1].status").value("PENDING"));
 
         // === 5. EXECUTE STEP 2 ===
-        mockMvc.perform(post("/api/simulator/sessions/" + sessionId + "/steps/execute"))
+        mockMvc.perform(post("/api/simulator/sessions/" + sessionId + "/steps/execute")
+                .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER"))))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.success").value(true))
             .andExpect(jsonPath("$.stepNumber").value(2));
 
         // === 6. STATUS — sesja powinna być COMPLETED ===
-        mockMvc.perform(get("/api/simulator/sessions/" + sessionId + "/status"))
+        mockMvc.perform(get("/api/simulator/sessions/" + sessionId + "/status")
+                .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER"))))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.status").value("COMPLETED"))
             .andExpect(jsonPath("$.currentStep").value(2))
@@ -112,7 +120,8 @@ class GuidedCookingFlowTest {
             .andExpect(jsonPath("$.history[1].status").value("EXECUTED"));
 
         // === 7. HISTORY — pełna historia ===
-        mockMvc.perform(get("/api/simulator/sessions/" + sessionId + "/history"))
+        mockMvc.perform(get("/api/simulator/sessions/" + sessionId + "/history")
+                .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER"))))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$", hasSize(2)))
             .andExpect(jsonPath("$[0].stepNumber").value(1))
@@ -132,6 +141,7 @@ class GuidedCookingFlowTest {
         // Start
         String sessionId = extractSessionId(
             mockMvc.perform(post("/api/simulator/sessions/start")
+                    .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER")))
                     .contentType(MediaType.APPLICATION_JSON)
                     .content("{\"recipeId\":\"52772\"}"))
                 .andExpect(status().isCreated())
@@ -139,32 +149,38 @@ class GuidedCookingFlowTest {
         );
 
         // Execute step 1
-        mockMvc.perform(post("/api/simulator/sessions/" + sessionId + "/steps/execute"))
+        mockMvc.perform(post("/api/simulator/sessions/" + sessionId + "/steps/execute")
+                .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER"))))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.stepNumber").value(1));
 
         // Execute step 2
-        mockMvc.perform(post("/api/simulator/sessions/" + sessionId + "/steps/execute"))
+        mockMvc.perform(post("/api/simulator/sessions/" + sessionId + "/steps/execute")
+                .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER"))))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.stepNumber").value(2));
 
         // Verify COMPLETED
-        mockMvc.perform(get("/api/simulator/sessions/" + sessionId + "/status"))
+        mockMvc.perform(get("/api/simulator/sessions/" + sessionId + "/status")
+                .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER"))))
             .andExpect(jsonPath("$.status").value("COMPLETED"));
 
         // REWIND to step 1
-        mockMvc.perform(post("/api/simulator/sessions/" + sessionId + "/rewind?stepNumber=1"))
+        mockMvc.perform(post("/api/simulator/sessions/" + sessionId + "/rewind?stepNumber=1")
+                .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER"))))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.status").value("RUNNING"))
             .andExpect(jsonPath("$.currentStep").value(1));
 
         // Re-execute step 2
-        mockMvc.perform(post("/api/simulator/sessions/" + sessionId + "/steps/execute"))
+        mockMvc.perform(post("/api/simulator/sessions/" + sessionId + "/steps/execute")
+                .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER"))))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.stepNumber").value(2));
 
         // Verify COMPLETED again
-        mockMvc.perform(get("/api/simulator/sessions/" + sessionId + "/status"))
+        mockMvc.perform(get("/api/simulator/sessions/" + sessionId + "/status")
+                .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER"))))
             .andExpect(jsonPath("$.status").value("COMPLETED"));
     }
 
@@ -178,6 +194,7 @@ class GuidedCookingFlowTest {
 
         String sessionId = extractSessionId(
             mockMvc.perform(post("/api/simulator/sessions/start")
+                    .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER")))
                     .contentType(MediaType.APPLICATION_JSON)
                     .content("{\"recipeId\":\"52772\"}"))
                 .andExpect(status().isCreated())
@@ -186,6 +203,7 @@ class GuidedCookingFlowTest {
 
         // processStep 1
         mockMvc.perform(post("/api/simulator/sessions/" + sessionId + "/step")
+                .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER")))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"stepNumber\":1,\"description\":\"Exec 1\",\"durationSeconds\":5}"))
             .andExpect(status().isOk())
@@ -193,27 +211,32 @@ class GuidedCookingFlowTest {
 
         // processStep 2
         mockMvc.perform(post("/api/simulator/sessions/" + sessionId + "/step")
+                .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER")))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"stepNumber\":2,\"description\":\"Exec 2\",\"durationSeconds\":5}"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.success").value(true));
 
         // Verify COMPLETED
-        mockMvc.perform(get("/api/simulator/sessions/" + sessionId + "/status"))
+        mockMvc.perform(get("/api/simulator/sessions/" + sessionId + "/status")
+                .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER"))))
             .andExpect(jsonPath("$.status").value("COMPLETED"));
     }
 
     @Test
     @DisplayName("Error flow: operacja na nieistniejącej sesji → 404")
     void errorFlow_sessionNotFound() throws Exception {
-        mockMvc.perform(post("/api/simulator/sessions/fake-id/steps/execute"))
+        mockMvc.perform(post("/api/simulator/sessions/fake-id/steps/execute")
+                .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER"))))
             .andExpect(status().isNotFound())
             .andExpect(jsonPath("$.code").value("SIMULATION_NOT_FOUND"));
 
-        mockMvc.perform(get("/api/simulator/sessions/fake-id/status"))
+        mockMvc.perform(get("/api/simulator/sessions/fake-id/status")
+                .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER"))))
             .andExpect(status().isNotFound());
 
-        mockMvc.perform(get("/api/simulator/sessions/fake-id/history"))
+        mockMvc.perform(get("/api/simulator/sessions/fake-id/history")
+                .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER"))))
             .andExpect(status().isNotFound());
     }
 


### PR DESCRIPTION
Wdrożono zależność spring-boot-starter-oauth2-resource-server Zależność znajduje się już w plikach pom.xml we wszystkich docelowych serwisach (main-service, cooking-session-service oraz simulator-service).

 Ustawiono adres emitenta tokenu (Issuer URI / JWK Set URI) Adresy są skonfigurowane w scentralizowanym repozytorium konfiguracyjnym w plikach config-repo/application.yml oraz gateway-service.yml i korzystają ze zmiennych środowiskowych (wskazujących na zewnętrzne URL: KEYCLOAK_PUBLIC_URL dla weryfikacji tokenów oraz KEYCLOAK_INTERNAL_URL dla pobierania kluczy publicznych).

 Wdrożono specyficzny dekoder ról (przez JwtAuthenticationConverter) W każdym z trzech mikroserwisów zaimplementowano klasę KeycloakJwtAuthenticationConverter, która realizuje interfejs Converter<Jwt, AbstractAuthenticationToken>. Poprawnie mapuje ona claim realm_access.roles z formatu Keycloaka na zbiór obiektów typu SimpleGrantedAuthority (dodając wymagany przez Springa przedrostek ROLE_). Dla serwisów reaktywnych (jak np. cooking-session-service) dekoder ten jest dodatkowo poprawnie opakowany przez klasę ReactiveJwtAuthenticationConverterAdapter.

 Nałożono zabezpieczenia (@PreAuthorize / SecurityFilterChain) Konfiguracja bezpieczeństwa w plikach SecurityConfig chroni każdy endpoint poza Actuatorami (/actuator/health i /info). Dodatkowo w kontrolerach umieszczone są już adnotacje @PreAuthorize, co pozwala na kontrolę uprawnień na podstawie wyodrębnionych ról.

 Zweryfikowano działanie filtrów bezpieczeństwa (kody błędów) Wszystkie klasy SecurityConfig definiują reguły zwracania wyjątków (np. blok exceptionHandling):

Dla błędów uwierzytelnienia (brak tokenu lub niewłaściwa sygnatura / emitent) konfigurowany jest HttpStatusEntryPoint z kodem 401 Unauthorized.
W razie braku właściwych uprawnień (np. wywołanie metody chronionej @PreAuthorize("hasRole('ADMIN')") bez roli) zdefiniowany jest accessDeniedHandler odrzucający request z błędem 403 Forbidden. 

---

Dodałem plik insomni, żeby przykładowy request był szybki do sprawdzenia

---
Closes #180 