### PR TITLE
usuniecie webmvctest z pom

### DIFF
--- a/cooking-session-service/pom.xml
+++ b/cooking-session-service/pom.xml
@@ -98,11 +98,7 @@
             <artifactId>h2</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-webmvc-test</artifactId>
-            <scope>test</scope>
-        </dependency>
+
     </dependencies>
 
     <dependencyManagement>


### PR DESCRIPTION
nie było zbyt dużo starego kodu, w sumie to nie było go wcale, więc tylko usunąłem spring-boot-starter-webmvc-test z pom.xml

Closes #181 