### PR TITLE
Naprawa generowania kroków przepisów przez klienta Groq

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,6 @@ logs/
 # Environment files
 .env
 *.env.local
+SUMATYWNY POSTER/
 
 Prez*.md

--- a/main-service/src/main/java/com/cookmate/main/service/GroqClient.java
+++ b/main-service/src/main/java/com/cookmate/main/service/GroqClient.java
@@ -22,7 +22,7 @@ public class GroqClient {
     private static final Logger logger = LoggerFactory.getLogger(GroqClient.class);
     private static final String GROQ_API_URL = "https://api.groq.com/openai/v1/chat/completions";
     //    Zmien na model GPT-OSS20B albo 120B
-    private static final String MODEL = "llama-3.1-8b-instant";
+    private static final String MODEL = "openai/gpt-oss-120b";
     private static final double TEMPERATURE = 0.7;
 
     private final RestClient restClient;
@@ -222,7 +222,7 @@ public class GroqClient {
                             ),
                             "duration_minutes", java.util.Map.of("type", "integer")
                         ),
-                        "required", List.of("step_number", "description", "action", "parameters", "duration_minutes"),
+                        "required", List.of("step_number", "description", "main_ingredient", "action", "parameters", "duration_minutes"),
                         "additionalProperties", false
                     )
                 )


### PR DESCRIPTION
Podczas generowania kroków dla przepisów, które nie miały ich jeszcze w bazie danych, aplikacja zwracała błąd `502 Bad Gateway` (spowodowany błędem komunikacji `400 Bad Request` z zewnętrznym API Groq). Przyczyną były dwa problemy:
1. **Brak wsparcia dla formatu:** Używany dotychczas model `llama-3.1-8b-instant` nie wspiera strukturyzowania danych wyjściowych za pomocą parametru `json_schema`.
2. **Niezgodność ze specyfikacją Strict JSON Schema:** Zdefiniowane w kodzie pole `main_ingredient` nie znajdowało się na liście pól wymaganych (`required`). W trybie `strict: true` (Structured Outputs) każdy zadeklarowany parametr w sekcji `properties` musi bezwzględnie znaleźć się w tablicy `required`.
##  Rozwiązanie
* **Zmiana modelu LLM:** Zastąpiono model w `GroqClient.java` na **`openai/gpt-oss-120b`**, który w pełni wspiera format `json_schema` na platformie Groq.
* **Poprawka schematu walidacyjnego:** Dodano `"main_ingredient"` do listy wymaganych pól w metodzie `buildSchemaMap()` w klasie `GroqClient.java`, dzięki czemu schemat pomyślnie przechodzi walidację API Groq.