### PR TITLE
Skrypt automatyzujący deploy - Github action

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -17,7 +17,7 @@ jobs:
       uses: appleboy/ssh-action@v1.0.3
       with:
         host: ${{ secrets.AWS_HOST }}
-        username: ${{ secrets.AWS_USER }}
+        username: ubuntu
         key: ${{ secrets.AWS_SSH_KEY }}
         script: |
           cd ~/CookMate

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,25 @@
+name: Deploy CookMate to AWS
+
+on:
+  push:
+    branches:
+      - main 
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Deploy to AWS via SSH
+      uses: appleboy/ssh-action@v1.0.3
+      with:
+        host: ${{ secrets.AWS_HOST }}
+        username: ${{ secrets.AWS_USER }}
+        key: ${{ secrets.AWS_SSH_KEY }}
+        script: |
+          cd ~/CookMate
+          git pull origin main
+          docker compose up -d --build

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,7 +3,7 @@ name: Deploy CookMate to AWS
 on:
   push:
     branches:
-      - main 
+      - main
 
 jobs:
   deploy:
@@ -22,4 +22,5 @@ jobs:
         script: |
           cd ~/CookMate
           git pull origin main
-          docker compose up -d --build
+          docker compose up -d --build --remove-orphans
+          docker image prune -f


### PR DESCRIPTION
## 🚀 Wdrożenie automatycznego potoku CD (GitHub Actions)

Zaimplementowałem pełną automatyzację Continuous Deployment dla naszej aplikacji. Od teraz nie musimy ręcznie logować się na serwer przez SSH, żeby wrzucić nowe zmiany – GitHub Actions zrobi to za nas przy każdym pushu na gałąź `main`.

### 🛠️ Co dokładnie wjeżdża w tym PR?
* **Automatyczne wdrażanie:** Dodano plik `.github/workflows/deploy.yml`, który odpala się po pushu na `main`, łączy się z naszym nowym serwerem AWS i aktualizuje projekt.
* **Bezpieczeństwo (Secrets):** Dane dostępowe serwera (IP oraz klucz `.pem`) zostały ukryte w GitHub Secrets (`AWS_HOST`, `AWS_SSH_KEY`). Nikt nieuprawniony nie podejrzy naszych kluczy w kodzie.
* **Inteligentny restart:** Używamy flagi `--build`, aby Docker sam skompilował nowe zmiany, oraz `--remove-orphans`, żeby w tle nie wisiały żadne stare, porzucone kontenery ze starych wersji kodu.
* **Czyszczenie dysku:** Na koniec potoku odpala się `docker image prune -f`. Dzięki temu serwer automatycznie usuwa stare, niepotrzebne warstwy obrazów po przebudowaniu aplikacji, więc dysk nam się nie zapcha.

### 🧪 Status weryfikacji
Potok przetestowany na nowej instancji AWS – wszystko przechodzi na zielono, a serwer sam pięknie wstaje z nowym kodem w kilkadziesiąt sekund. Jak tylko to zmergujemy, poprawki frontu od razu same wskoczą na serwer!