### PR TITLE
212 izolacja sesji gotowania na poziomie użytkownika multi user session isolation

### DIFF
--- a/config-repo/application.yml
+++ b/config-repo/application.yml
@@ -10,15 +10,18 @@ management:
 
 logging:
   level:
-    com.cookmate: DEBUG
+    com.cookmate: INFO
     org.springframework.cloud: INFO
 
 # Centralized OAuth2 Resource Server configuration for all business microservices
 # Each service validates JWT tokens issued by Keycloak
 spring:
+  threads:
+    virtual:
+      enabled: true
   datasource:
     hikari:
-      maximum-pool-size: 30       # 3 services × 30 = 90 + keycloak/sonar ~40 = 130 << max_connections=500
+      maximum-pool-size: 300       # increased pool for higher VU load
       minimum-idle: 5
       connection-timeout: 30000   # 30s before throwing exception (prevent thread starvation)
       idle-timeout: 600000        # 10 min idle before releasing connection

--- a/config-repo/application.yml
+++ b/config-repo/application.yml
@@ -18,7 +18,10 @@ logging:
 spring:
   datasource:
     hikari:
-      maximum-pool-size: 100
+      maximum-pool-size: 30       # 3 services × 30 = 90 + keycloak/sonar ~40 = 130 << max_connections=500
+      minimum-idle: 5
+      connection-timeout: 30000   # 30s before throwing exception (prevent thread starvation)
+      idle-timeout: 600000        # 10 min idle before releasing connection
   security:
     oauth2:
       resourceserver:

--- a/config-repo/application.yml
+++ b/config-repo/application.yml
@@ -16,6 +16,9 @@ logging:
 # Centralized OAuth2 Resource Server configuration for all business microservices
 # Each service validates JWT tokens issued by Keycloak
 spring:
+  datasource:
+    hikari:
+      maximum-pool-size: 100
   security:
     oauth2:
       resourceserver:

--- a/config-repo/gateway-service.yml
+++ b/config-repo/gateway-service.yml
@@ -67,5 +67,5 @@ management:
 
 logging:
   level:
-    org.springframework.cloud.gateway: TRACE
-    org.springframework.web.reactive: TRACE
+    org.springframework.cloud.gateway: WARN
+    org.springframework.web.reactive: WARN

--- a/cooking-session-service/src/main/java/com/cookmate/cookingsession/controller/CookingSessionController.java
+++ b/cooking-session-service/src/main/java/com/cookmate/cookingsession/controller/CookingSessionController.java
@@ -11,6 +11,8 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.codec.ServerSentEvent;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -31,39 +33,46 @@ public class CookingSessionController {
     @PostMapping("/progress")
     @PreAuthorize("hasRole('ROLE_USER')")
     public ResponseEntity<CookingSessionProgressDto> receiveProgress(
-            @Valid @RequestBody StepCompletionEventDto event
+            @Valid @RequestBody StepCompletionEventDto event,
+            @AuthenticationPrincipal Jwt jwt
     ) {
-        CookingSessionProgressDto saved = cookingSessionService.handleProgressEvent(event);
+        String userId = jwt.getSubject();
+        CookingSessionProgressDto saved = cookingSessionService.handleProgressEvent(event, userId);
         return ResponseEntity.status(HttpStatus.CREATED).body(saved);
     }
 
     @GetMapping("/recipes/{recipeId}/history")
     public ResponseEntity<List<CookingSessionProgressDto>> getHistory(
-            @PathVariable String recipeId
+            @PathVariable String recipeId,
+            @AuthenticationPrincipal Jwt jwt
     ) {
-        return ResponseEntity.ok(cookingSessionService.getHistoryByRecipe(recipeId));
+        return ResponseEntity.ok(cookingSessionService.getHistoryByRecipe(recipeId, jwt.getSubject()));
     }
 
     @GetMapping("/recipes/{recipeId}/latest")
     public ResponseEntity<CookingSessionProgressDto> getLatest(
-            @PathVariable String recipeId
+            @PathVariable String recipeId,
+            @AuthenticationPrincipal Jwt jwt
     ) {
-        CookingSessionProgressDto latest = cookingSessionService.getLatestByRecipe(recipeId);
+        CookingSessionProgressDto latest = cookingSessionService.getLatestByRecipe(recipeId, jwt.getSubject());
         return latest == null ? ResponseEntity.notFound().build() : ResponseEntity.ok(latest);
     }
 
     @GetMapping("/recipes/{recipeId}/active")
     public ResponseEntity<ActiveCookingSessionDto> getActiveSession(
-            @PathVariable String recipeId
+            @PathVariable String recipeId,
+            @AuthenticationPrincipal Jwt jwt
     ) {
-        return cookingSessionService.getActiveSessionDetails(recipeId)
+        return cookingSessionService.getActiveSessionDetails(recipeId, jwt.getSubject())
                 .map(ResponseEntity::ok)
                 .orElseGet(() -> ResponseEntity.notFound().build());
     }
 
     @GetMapping("/active")
-    public ResponseEntity<ActiveCookingSessionDto> getActiveSessionGlobal() {
-        return cookingSessionService.getActiveSessionGlobal()
+    public ResponseEntity<ActiveCookingSessionDto> getActiveSessionGlobal(
+            @AuthenticationPrincipal Jwt jwt
+    ) {
+        return cookingSessionService.getActiveSessionGlobal(jwt.getSubject())
                 .map(ResponseEntity::ok)
                 .orElseGet(() -> ResponseEntity.notFound().build());
     }
@@ -71,17 +80,19 @@ public class CookingSessionController {
     @PostMapping("/sessions/{sessionId}/complete")
     @PreAuthorize("hasRole('ROLE_USER')")
     public ResponseEntity<Void> completeSession(
-            @PathVariable String sessionId
+            @PathVariable String sessionId,
+            @AuthenticationPrincipal Jwt jwt
     ) {
-        cookingSessionService.completeSession(sessionId);
+        cookingSessionService.completeSession(sessionId, jwt.getSubject());
         return ResponseEntity.ok().build();
     }
 
     @GetMapping(value = "/recipes/{recipeId}/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public Flux<ServerSentEvent<CookingSessionProgressDto>> streamProgress(
-            @PathVariable String recipeId
+            @PathVariable String recipeId,
+            @AuthenticationPrincipal Jwt jwt
     ) {
-        return cookingSessionService.streamProgress(recipeId)
+        return cookingSessionService.streamProgress(recipeId, jwt.getSubject())
                 .map(progress -> ServerSentEvent.builder(progress)
                         .event("progress")
                         .build());

--- a/cooking-session-service/src/main/java/com/cookmate/cookingsession/dto/CookingSessionProgressDto.java
+++ b/cooking-session-service/src/main/java/com/cookmate/cookingsession/dto/CookingSessionProgressDto.java
@@ -7,5 +7,6 @@ public record CookingSessionProgressDto(
         String recipeId,
         Integer stepNumber,
         String status,
-        LocalDateTime executedAt
+        LocalDateTime executedAt,
+        String userId
 ) {}

--- a/cooking-session-service/src/main/java/com/cookmate/cookingsession/model/CookingSession.java
+++ b/cooking-session-service/src/main/java/com/cookmate/cookingsession/model/CookingSession.java
@@ -25,7 +25,8 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "cooking_sessions", indexes = {
         @Index(name = "idx_cooking_sessions_recipe_id", columnList = "recipe_id"),
-        @Index(name = "idx_cooking_sessions_status", columnList = "status")
+        @Index(name = "idx_cooking_sessions_status", columnList = "status"),
+        @Index(name = "idx_cooking_sessions_user_id", columnList = "user_id")
 })
 @EntityListeners(AuditingEntityListener.class)
 public class CookingSession {
@@ -36,6 +37,9 @@ public class CookingSession {
 
     @Column(name = "recipe_id", nullable = false)
     private String recipeId;
+
+    @Column(name = "user_id", nullable = false, length = 36)
+    private String userId;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)

--- a/cooking-session-service/src/main/java/com/cookmate/cookingsession/model/CookingSessionProgress.java
+++ b/cooking-session-service/src/main/java/com/cookmate/cookingsession/model/CookingSessionProgress.java
@@ -31,7 +31,8 @@ import java.time.LocalDateTime;
         },
         indexes = {
                 @Index(name = "idx_cooking_progress_session_id", columnList = "session_id"),
-                @Index(name = "idx_cooking_progress_recipe_id", columnList = "recipe_id")
+                @Index(name = "idx_cooking_progress_recipe_id", columnList = "recipe_id"),
+                @Index(name = "idx_cooking_progress_user_id", columnList = "user_id")
         }
 )
 @EntityListeners(AuditingEntityListener.class)
@@ -43,6 +44,9 @@ public class CookingSessionProgress {
 
     @Column(name = "session_id", nullable = false)
     private String sessionId;
+
+    @Column(name = "user_id", nullable = false, length = 36)
+    private String userId;
 
     @Column(name = "recipe_id", nullable = false)
     private String recipeId;

--- a/cooking-session-service/src/main/java/com/cookmate/cookingsession/repository/CookingSessionRepository.java
+++ b/cooking-session-service/src/main/java/com/cookmate/cookingsession/repository/CookingSessionRepository.java
@@ -11,12 +11,15 @@ import java.util.Optional;
 @Repository
 public interface CookingSessionRepository extends JpaRepository<CookingSession, String> {
 
-    List<CookingSession> findByRecipeIdAndStatus(String recipeId, CookingSessionStatus status);
+    List<CookingSession> findByRecipeIdAndStatusAndUserId(String recipeId, CookingSessionStatus status, String userId);
 
-    Optional<CookingSession> findFirstByRecipeIdAndStatusOrderByLastExecutedAtDesc(
+    Optional<CookingSession> findFirstByRecipeIdAndStatusAndUserIdOrderByLastExecutedAtDesc(
             String recipeId,
-            CookingSessionStatus status
+            CookingSessionStatus status,
+            String userId
     );
 
-    List<CookingSession> findByStatus(CookingSessionStatus status);
+    List<CookingSession> findByStatusAndUserId(CookingSessionStatus status, String userId);
+
+    Optional<CookingSession> findBySessionIdAndUserId(String sessionId, String userId);
 }

--- a/cooking-session-service/src/main/java/com/cookmate/cookingsession/service/CookingSessionService.java
+++ b/cooking-session-service/src/main/java/com/cookmate/cookingsession/service/CookingSessionService.java
@@ -34,9 +34,9 @@ public class CookingSessionService {
             .directBestEffort();
 
     @Transactional
-    public CookingSessionProgressDto handleProgressEvent(StepCompletionEventDto event) {
-        logger.info("Otrzymano event postępu: sessionId={}, stepNumber={}, recipeId={}",
-                event.sessionId(), event.stepNumber(), event.recipeId());
+    public CookingSessionProgressDto handleProgressEvent(StepCompletionEventDto event, String userId) {
+        logger.info("Otrzymano event postępu: sessionId={}, stepNumber={}, recipeId={}, userId={}",
+                event.sessionId(), event.stepNumber(), event.recipeId(), userId);
 
         Optional<CookingSessionProgress> existing = cookingSessionProgressRepository
                 .findFirstBySessionIdAndStepNumber(event.sessionId(), event.stepNumber());
@@ -45,7 +45,7 @@ public class CookingSessionService {
             return toProgressDto(existing.get());
         }
 
-        upsertSession(event);
+        upsertSession(event, userId);
 
         CookingSessionProgress progress = CookingSessionProgress.builder()
                 .sessionId(event.sessionId())
@@ -53,6 +53,7 @@ public class CookingSessionService {
                 .stepNumber(event.stepNumber())
                 .status(event.status())
                 .executedAt(event.executedAt())
+                .userId(userId)
                 .build();
 
         CookingSessionProgress saved = cookingSessionProgressRepository.save(progress);
@@ -64,8 +65,8 @@ public class CookingSessionService {
         return toProgressDto(saved);
     }
 
-    public List<CookingSessionProgressDto> getHistoryByRecipe(String recipeId) {
-        Optional<CookingSession> activeSession = getActiveSession(recipeId);
+    public List<CookingSessionProgressDto> getHistoryByRecipe(String recipeId, String userId) {
+        Optional<CookingSession> activeSession = getActiveSession(recipeId, userId);
         if (activeSession.isEmpty()) {
             return List.of();
         }
@@ -76,8 +77,8 @@ public class CookingSessionService {
                 .toList();
     }
 
-    public CookingSessionProgressDto getLatestByRecipe(String recipeId) {
-        Optional<CookingSession> activeSession = getActiveSession(recipeId);
+    public CookingSessionProgressDto getLatestByRecipe(String recipeId, String userId) {
+        Optional<CookingSession> activeSession = getActiveSession(recipeId, userId);
         if (activeSession.isEmpty()) {
             return null;
         }
@@ -87,53 +88,55 @@ public class CookingSessionService {
                 .orElse(null);
     }
 
-    public Optional<ActiveCookingSessionDto> getActiveSessionDetails(String recipeId) {
-        return getActiveSession(recipeId).map(this::toActiveDto);
+    public Optional<ActiveCookingSessionDto> getActiveSessionDetails(String recipeId, String userId) {
+        return getActiveSession(recipeId, userId).map(this::toActiveDto);
     }
 
-    public Optional<ActiveCookingSessionDto> getActiveSessionGlobal() {
-        return cookingSessionRepository.findByStatus(CookingSessionStatus.RUNNING)
+    public Optional<ActiveCookingSessionDto> getActiveSessionGlobal(String userId) {
+        return cookingSessionRepository.findByStatusAndUserId(CookingSessionStatus.RUNNING, userId)
                 .stream()
                 .findFirst()
                 .map(this::toActiveDto);
     }
 
     @Transactional
-    public void completeSession(String sessionId) {
-        cookingSessionRepository.findById(sessionId).ifPresent(session -> {
+    public void completeSession(String sessionId, String userId) {
+        cookingSessionRepository.findBySessionIdAndUserId(sessionId, userId).ifPresent(session -> {
             session.setStatus(CookingSessionStatus.COMPLETED);
             session.setCompletedAt(LocalDateTime.now());
             cookingSessionRepository.save(session);
-            logger.info("Session {} manually completed", sessionId);
+            logger.info("Session {} manually completed for user {}", sessionId, userId);
         });
     }
 
-    public Flux<CookingSessionProgressDto> streamProgress(String recipeId) {
+    public Flux<CookingSessionProgressDto> streamProgress(String recipeId, String userId) {
         return progressSink.asFlux()
-                .filter(event -> event.recipeId().equals(recipeId));
+                .filter(event -> event.recipeId().equals(recipeId) && userId.equals(event.userId()));
     }
 
-    private Optional<CookingSession> getActiveSession(String recipeId) {
-        return cookingSessionRepository.findFirstByRecipeIdAndStatusOrderByLastExecutedAtDesc(
+    private Optional<CookingSession> getActiveSession(String recipeId, String userId) {
+        return cookingSessionRepository.findFirstByRecipeIdAndStatusAndUserIdOrderByLastExecutedAtDesc(
                 recipeId,
-                CookingSessionStatus.RUNNING
+                CookingSessionStatus.RUNNING,
+                userId
         );
     }
 
-    private CookingSession upsertSession(StepCompletionEventDto event) {
+    private CookingSession upsertSession(StepCompletionEventDto event, String userId) {
         CookingSession session = cookingSessionRepository.findById(event.sessionId()).orElse(null);
         boolean isCompletedEvent = "COMPLETED".equals(event.status());
         CookingSessionStatus targetStatus = isCompletedEvent ? CookingSessionStatus.COMPLETED : CookingSessionStatus.RUNNING;
 
         if (targetStatus == CookingSessionStatus.RUNNING) {
-            completeAllOtherSessionsGlobally(event.sessionId());
+            completeAllOtherSessionsGlobally(event.sessionId(), userId);
         }
 
         if (session == null) {
-            completeOtherSessions(event.recipeId(), event.sessionId());
+            completeOtherSessions(event.recipeId(), event.sessionId(), userId);
             session = CookingSession.builder()
                     .sessionId(event.sessionId())
                     .recipeId(event.recipeId())
+                    .userId(userId)
                     .status(targetStatus)
                     .currentStep(event.stepNumber())
                     .lastExecutedAt(event.executedAt())
@@ -144,6 +147,7 @@ public class CookingSessionService {
             session.setCurrentStep(Math.max(currentStep, event.stepNumber()));
             session.setLastExecutedAt(event.executedAt());
             session.setStatus(targetStatus);
+            session.setUserId(userId);
             if (isCompletedEvent) {
                 session.setCompletedAt(event.executedAt());
             } else {
@@ -153,9 +157,9 @@ public class CookingSessionService {
         return cookingSessionRepository.save(session);
     }
 
-    private void completeOtherSessions(String recipeId, String currentSessionId) {
+    private void completeOtherSessions(String recipeId, String currentSessionId, String userId) {
         List<CookingSession> runningSessions = cookingSessionRepository
-                .findByRecipeIdAndStatus(recipeId, CookingSessionStatus.RUNNING);
+                .findByRecipeIdAndStatusAndUserId(recipeId, CookingSessionStatus.RUNNING, userId);
         if (runningSessions.isEmpty()) {
             return;
         }
@@ -175,8 +179,8 @@ public class CookingSessionService {
     }
 
     @Transactional
-    public void completeAllOtherSessionsGlobally(String currentSessionId) {
-        List<CookingSession> runningSessions = cookingSessionRepository.findByStatus(CookingSessionStatus.RUNNING);
+    public void completeAllOtherSessionsGlobally(String currentSessionId, String userId) {
+        List<CookingSession> runningSessions = cookingSessionRepository.findByStatusAndUserId(CookingSessionStatus.RUNNING, userId);
         if (runningSessions.isEmpty()) {
             return;
         }
@@ -188,7 +192,7 @@ public class CookingSessionService {
                 session.setStatus(CookingSessionStatus.COMPLETED);
                 session.setCompletedAt(now);
                 updated = true;
-                logger.info("Session {} globally completed due to new active session {}", session.getSessionId(), currentSessionId);
+                logger.info("Session {} globally completed for user {} due to new active session {}", session.getSessionId(), userId, currentSessionId);
             }
         }
         if (updated) {
@@ -202,7 +206,8 @@ public class CookingSessionService {
                 progress.getRecipeId(),
                 progress.getStepNumber(),
                 progress.getStatus(),
-                progress.getExecutedAt()
+                progress.getExecutedAt(),
+                progress.getUserId()
         );
     }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,11 +20,12 @@ services:
     image: postgres:18-alpine
     container_name: cookmate-postgres
     restart: unless-stopped
+    # max_connections via command works even when volume already exists (unlike POSTGRES_INITDB_ARGS)
+    command: postgres -c max_connections=500 -c shared_buffers=256MB
     environment:
       POSTGRES_DB: ${DB_NAME:-cookmate}
       POSTGRES_USER: ${DB_USER:-cookmate}
       POSTGRES_PASSWORD: ${DB_PASS:-cookmate}
-      POSTGRES_INITDB_ARGS: "-c max_connections=200"
     ports:
       - "5432:5432"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     container_name: cookmate-postgres
     restart: unless-stopped
     # max_connections via command works even when volume already exists (unlike POSTGRES_INITDB_ARGS)
-    command: postgres -c max_connections=500 -c shared_buffers=256MB
+    command: postgres -c max_connections=800 -c shared_buffers=256MB
     environment:
       POSTGRES_DB: ${DB_NAME:-cookmate}
       POSTGRES_USER: ${DB_USER:-cookmate}

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -6,6 +6,11 @@ spring:
   threads:
     virtual:
       enabled: true
+  cloud:
+    gateway:
+      httpclient:
+        connect-timeout: 60000
+        response-timeout: 120000
 
 # Fallback values (overridden by config-server)
 server:

--- a/simulator-service/src/main/java/com/cookmate/simulator/client/CookingSessionClient.java
+++ b/simulator-service/src/main/java/com/cookmate/simulator/client/CookingSessionClient.java
@@ -3,6 +3,7 @@ package com.cookmate.simulator.client;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 
 import java.util.Map;
 
@@ -16,8 +17,12 @@ public interface CookingSessionClient {
      * Wysyła notyfikację o wykonanym kroku do cooking-session-service.
      * Event zawiera: sessionId, stepNumber, status, executedAt, recipeId
      *
+     * @param authHeader nagłówek autoryzacji JWT
      * @param event mapa zawierająca dane o wykonanym kroku
      */
     @PostMapping("/api/cooking-sessions/progress")
-    void notifyStepCompleted(@RequestBody Map<String, Object> event);
+    void notifyStepCompleted(
+            @RequestHeader("Authorization") String authHeader,
+            @RequestBody Map<String, Object> event
+    );
 }

--- a/simulator-service/src/main/java/com/cookmate/simulator/config/FeignConfig.java
+++ b/simulator-service/src/main/java/com/cookmate/simulator/config/FeignConfig.java
@@ -1,0 +1,30 @@
+package com.cookmate.simulator.config;
+
+import feign.RequestInterceptor;
+import feign.RequestTemplate;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Configuration
+public class FeignConfig {
+
+    @Bean
+    public RequestInterceptor requestInterceptor() {
+        return new RequestInterceptor() {
+            @Override
+            public void apply(RequestTemplate template) {
+                ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+                if (attributes != null) {
+                    HttpServletRequest request = attributes.getRequest();
+                    String authorization = request.getHeader("Authorization");
+                    if (authorization != null && !template.headers().containsKey("Authorization")) {
+                        template.header("Authorization", authorization);
+                    }
+                }
+            }
+        };
+    }
+}

--- a/simulator-service/src/main/java/com/cookmate/simulator/config/FeignConfig.java
+++ b/simulator-service/src/main/java/com/cookmate/simulator/config/FeignConfig.java
@@ -5,6 +5,7 @@ import feign.RequestTemplate;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import java.util.concurrent.TimeUnit;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
@@ -27,4 +28,12 @@ public class FeignConfig {
             }
         };
     }
+    @Bean
+    public feign.Request.Options feignOptions() {
+        // 60 seconds connect timeout, 120 seconds read timeout
+        return new feign.Request.Options(60000, TimeUnit.MILLISECONDS,
+                                         120000, TimeUnit.MILLISECONDS,
+                                         true);
+    }
+
 }

--- a/simulator-service/src/main/java/com/cookmate/simulator/controller/SimulatorController.java
+++ b/simulator-service/src/main/java/com/cookmate/simulator/controller/SimulatorController.java
@@ -18,11 +18,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -42,8 +45,12 @@ public class SimulatorController {
     @PreAuthorize("hasRole('ROLE_USER')")
     @Operation(summary = "Start simulation session", description = "Creates a new session and loads recipe steps from main-service.")
     @ApiResponse(responseCode = "201", description = "Session started", content = @Content(schema = @Schema(implementation = SimulationStatusResponseDto.class)))
-    public ResponseEntity<SimulationStatusResponseDto> startSimulation(@Valid @RequestBody StartSimulationRequestDto request) {
-        return ResponseEntity.status(HttpStatus.CREATED).body(simulationService.startSession(request));
+    public ResponseEntity<SimulationStatusResponseDto> startSimulation(
+            @Valid @RequestBody StartSimulationRequestDto request,
+            @AuthenticationPrincipal Jwt jwt,
+            @RequestHeader("Authorization") String authHeader
+    ) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(simulationService.startSession(request, jwt.getSubject(), authHeader));
     }
 
     @PostMapping("/sessions/{sessionId}/step")
@@ -52,17 +59,23 @@ public class SimulatorController {
     @ApiResponse(responseCode = "200", description = "Step execution result", content = @Content(schema = @Schema(implementation = StepExecutionResultDto.class)))
     public ResponseEntity<StepExecutionResultDto> receiveStep(
             @Parameter(description = "Simulation session identifier") @PathVariable String sessionId,
-            @Valid @RequestBody RecipeStepRequestDto stepDto
+            @Valid @RequestBody RecipeStepRequestDto stepDto,
+            @AuthenticationPrincipal Jwt jwt,
+            @RequestHeader("Authorization") String authHeader
     ) {
-        return ResponseEntity.ok(simulationService.processStep(sessionId, stepDto));
+        return ResponseEntity.ok(simulationService.processStep(sessionId, stepDto, jwt.getSubject(), authHeader));
     }
 
     @PostMapping("/sessions/{sessionId}/steps/execute")
     @PreAuthorize("hasRole('ROLE_USER')")
     @Operation(summary = "Execute next step", description = "One-click endpoint to execute the next pending step in the session.")
     @ApiResponse(responseCode = "200", description = "Step execution result", content = @Content(schema = @Schema(implementation = StepExecutionResultDto.class)))
-    public ResponseEntity<StepExecutionResultDto> executeNextStep(@PathVariable String sessionId) {
-        return ResponseEntity.ok(simulationService.executeNextStep(sessionId));
+    public ResponseEntity<StepExecutionResultDto> executeNextStep(
+            @PathVariable String sessionId,
+            @AuthenticationPrincipal Jwt jwt,
+            @RequestHeader("Authorization") String authHeader
+    ) {
+        return ResponseEntity.ok(simulationService.executeNextStep(sessionId, jwt.getSubject(), authHeader));
     }
 
     @PostMapping("/sessions/{sessionId}/rewind")
@@ -72,30 +85,43 @@ public class SimulatorController {
     public ResponseEntity<SimulationStatusResponseDto> rewindToStep(
             @Parameter(description = "Simulation session identifier") @PathVariable String sessionId,
             @Parameter(description = "Target step number (0..totalSteps)")
-            @RequestParam @Min(0) int stepNumber
+            @RequestParam @Min(0) int stepNumber,
+            @AuthenticationPrincipal Jwt jwt
     ) {
-        return ResponseEntity.ok(simulationService.rewindToStep(sessionId, stepNumber));
+        return ResponseEntity.ok(simulationService.rewindToStep(sessionId, stepNumber, jwt.getSubject()));
     }
 
     @GetMapping("/sessions/{sessionId}/status")
+    @PreAuthorize("hasRole('ROLE_USER')")
     @Operation(summary = "Get session status", description = "Returns current progress and full step history for a session.")
     @ApiResponse(responseCode = "200", description = "Session status", content = @Content(schema = @Schema(implementation = SimulationStatusResponseDto.class)))
-    public ResponseEntity<SimulationStatusResponseDto> getSimulationStatus(@PathVariable String sessionId) {
-        return ResponseEntity.ok(simulationService.getStatus(sessionId));
+    public ResponseEntity<SimulationStatusResponseDto> getSimulationStatus(
+            @PathVariable String sessionId,
+            @AuthenticationPrincipal Jwt jwt
+    ) {
+        return ResponseEntity.ok(simulationService.getStatus(sessionId, jwt.getSubject()));
     }
 
     @GetMapping("/sessions/{sessionId}/history")
+    @PreAuthorize("hasRole('ROLE_USER')")
     @Operation(summary = "Get session history", description = "Returns full ordered step history for a session.")
     @ApiResponse(responseCode = "200", description = "Step history")
-    public ResponseEntity<List<SimulationStepHistoryItemDto>> history(@PathVariable String sessionId) {
-        return ResponseEntity.ok(simulationService.history(sessionId));
+    public ResponseEntity<List<SimulationStepHistoryItemDto>> history(
+            @PathVariable String sessionId,
+            @AuthenticationPrincipal Jwt jwt
+    ) {
+        return ResponseEntity.ok(simulationService.history(sessionId, jwt.getSubject()));
     }
 
     @PostMapping("/sessions/{sessionId}/complete")
     @PreAuthorize("hasRole('ROLE_USER')")
     @Operation(summary = "Complete session manually", description = "Marks session as completed and notifies cooking-session-service.")
-    public ResponseEntity<Void> completeSession(@PathVariable String sessionId) {
-        simulationService.completeSession(sessionId);
+    public ResponseEntity<Void> completeSession(
+            @PathVariable String sessionId,
+            @AuthenticationPrincipal Jwt jwt,
+            @RequestHeader("Authorization") String authHeader
+    ) {
+        simulationService.completeSession(sessionId, jwt.getSubject(), authHeader);
         return ResponseEntity.ok().build();
     }
 }

--- a/simulator-service/src/main/java/com/cookmate/simulator/model/SimulationSession.java
+++ b/simulator-service/src/main/java/com/cookmate/simulator/model/SimulationSession.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
@@ -16,7 +17,9 @@ import lombok.Setter;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "simulation_sessions")
+@Table(name = "simulation_sessions", indexes = {
+        @Index(name = "idx_simulation_sessions_user_id", columnList = "user_id")
+})
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
@@ -26,6 +29,9 @@ public class SimulationSession {
     @Id
     @Column(nullable = false, updatable = false, length = 36)
     private String id;
+
+    @Column(name = "user_id", nullable = false, length = 36)
+    private String userId;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)

--- a/simulator-service/src/main/java/com/cookmate/simulator/repository/SimulationSessionRepository.java
+++ b/simulator-service/src/main/java/com/cookmate/simulator/repository/SimulationSessionRepository.java
@@ -6,8 +6,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface SimulationSessionRepository extends JpaRepository<SimulationSession, String> {
-    List<SimulationSession> findByStatus(SimulationStatus status);
+    List<SimulationSession> findByStatusAndUserId(SimulationStatus status, String userId);
+    Optional<SimulationSession> findByIdAndUserId(String id, String userId);
 }

--- a/simulator-service/src/main/java/com/cookmate/simulator/service/SimulationService.java
+++ b/simulator-service/src/main/java/com/cookmate/simulator/service/SimulationService.java
@@ -46,8 +46,8 @@ public class SimulationService {
     private final CookingSessionClient cookingSessionClient;
 
     @Transactional
-    public SimulationStatusResponseDto startSession(StartSimulationRequestDto request) {
-        List<SimulationSession> runningSessions = simulationSessionRepository.findByStatus(SimulationStatus.RUNNING);
+    public SimulationStatusResponseDto startSession(StartSimulationRequestDto request, String userId, String authHeader) {
+        List<SimulationSession> runningSessions = simulationSessionRepository.findByStatusAndUserId(SimulationStatus.RUNNING, userId);
 
         List<MainServiceStepDto> recipeSteps = fetchRecipeSteps(request.recipeId());
         if (recipeSteps.isEmpty()) {
@@ -58,6 +58,7 @@ public class SimulationService {
 
         SimulationSession session = new SimulationSession();
         session.setId(UUID.randomUUID().toString());
+        session.setUserId(userId);
         session.setStatus(SimulationStatus.RUNNING);
         session.setCurrentStep(0);
         session.setTotalSteps(normalizedSteps.size());
@@ -81,7 +82,8 @@ public class SimulationService {
                     oldSession.getCurrentStep(),
                     "COMPLETED",
                     LocalDateTime.now(),
-                    oldSession.getRecipeId()
+                    oldSession.getRecipeId(),
+                    authHeader
             );
         }
 
@@ -90,16 +92,17 @@ public class SimulationService {
                 0,
                 "RUNNING",
                 LocalDateTime.now(),
-                session.getRecipeId()
+                session.getRecipeId(),
+                authHeader
         );
 
         return mapStatusResponse(session, steps);
     }
 
     @Transactional
-    public StepExecutionResultDto processStep(String sessionId, RecipeStepRequestDto stepDto) {
+    public StepExecutionResultDto processStep(String sessionId, RecipeStepRequestDto stepDto, String userId, String authHeader) {
         synchronized (getExecutionLock(sessionId)) {
-            SimulationSession session = getSessionOrThrow(sessionId);
+            SimulationSession session = getSessionOrThrow(sessionId, userId);
             validateState(session, SimulationStatus.RUNNING, ONLY_RUNNING_ALLOWED);
 
             SimulationStep step = simulationStepRepository.findBySessionIdAndStepNumber(sessionId, stepDto.stepNumber())
@@ -118,7 +121,7 @@ public class SimulationService {
 
             // Asynchronicznie wysłać notyfikację do main-service
             boolean completed = session.getStatus() == SimulationStatus.COMPLETED;
-            notifyCookingSessionAsync(sessionId, stepDto.stepNumber(), completed ? "COMPLETED" : "EXECUTED", step.getExecutedAt(), session.getRecipeId());
+            notifyCookingSessionAsync(sessionId, stepDto.stepNumber(), completed ? "COMPLETED" : "EXECUTED", step.getExecutedAt(), session.getRecipeId(), authHeader);
 
             return StepExecutionResultDto.builder()
                     .stepNumber(stepDto.stepNumber())
@@ -128,9 +131,9 @@ public class SimulationService {
     }
 
     @Transactional
-    public StepExecutionResultDto executeNextStep(String sessionId) {
+    public StepExecutionResultDto executeNextStep(String sessionId, String userId, String authHeader) {
         synchronized (getExecutionLock(sessionId)) {
-            SimulationSession session = getSessionOrThrow(sessionId);
+            SimulationSession session = getSessionOrThrow(sessionId, userId);
             validateState(session, SimulationStatus.RUNNING, ONLY_RUNNING_ALLOWED);
 
             SimulationStep nextStep = simulationStepRepository
@@ -153,7 +156,7 @@ public class SimulationService {
 
             // Asynchronicznie wysłać notyfikację do main-service
             boolean completed = session.getStatus() == SimulationStatus.COMPLETED;
-            notifyCookingSessionAsync(sessionId, nextStep.getStepNumber(), completed ? "COMPLETED" : "EXECUTED", nextStep.getExecutedAt(), session.getRecipeId());
+            notifyCookingSessionAsync(sessionId, nextStep.getStepNumber(), completed ? "COMPLETED" : "EXECUTED", nextStep.getExecutedAt(), session.getRecipeId(), authHeader);
 
             return StepExecutionResultDto.builder()
                     .stepNumber(nextStep.getStepNumber())
@@ -163,9 +166,9 @@ public class SimulationService {
     }
 
     @Transactional
-    public SimulationStatusResponseDto rewindToStep(String sessionId, int stepNumber) {
+    public SimulationStatusResponseDto rewindToStep(String sessionId, int stepNumber, String userId) {
         synchronized (getExecutionLock(sessionId)) {
-            SimulationSession session = getSessionOrThrow(sessionId);
+            SimulationSession session = getSessionOrThrow(sessionId, userId);
             List<SimulationStep> steps = simulationStepRepository.findBySessionIdOrderByStepNumberAsc(sessionId);
 
             if (stepNumber < 0 || stepNumber > steps.size()) {
@@ -199,14 +202,14 @@ public class SimulationService {
         }
     }
 
-    public SimulationStatusResponseDto getStatus(String sessionId) {
-        SimulationSession session = getSessionOrThrow(sessionId);
+    public SimulationStatusResponseDto getStatus(String sessionId, String userId) {
+        SimulationSession session = getSessionOrThrow(sessionId, userId);
         List<SimulationStep> steps = simulationStepRepository.findBySessionIdOrderByStepNumberAsc(sessionId);
         return mapStatusResponse(session, steps);
     }
 
-    public List<SimulationStepHistoryItemDto> history(String sessionId) {
-        getSessionOrThrow(sessionId);
+    public List<SimulationStepHistoryItemDto> history(String sessionId, String userId) {
+        getSessionOrThrow(sessionId, userId);
         return mapHistory(simulationStepRepository.findBySessionIdOrderByStepNumberAsc(sessionId));
     }
 
@@ -214,8 +217,8 @@ public class SimulationService {
         return sessionExecutionLocks.computeIfAbsent(sessionId, key -> new Object());
     }
 
-    private SimulationSession getSessionOrThrow(String sessionId) {
-        return simulationSessionRepository.findById(sessionId)
+    private SimulationSession getSessionOrThrow(String sessionId, String userId) {
+        return simulationSessionRepository.findByIdAndUserId(sessionId, userId)
                 .orElseThrow(() -> new SimulationSessionNotFoundException(sessionId));
     }
 
@@ -321,7 +324,7 @@ public class SimulationService {
     }
 
     /**
-     * Asynchronicznie wysyła notyfikację o wykonanym kroku do cooking-session-service.
+     * Asynchronicznie wysłać notyfikację o wykonanym kroku do cooking-session-service.
      * Nie blokuje bieżącego wątku - wysyłka odbywa się w tle.
      * Jeśli wysyłka się nie powiedzie, loguje błąd ale nie rzuca wyjątku.
      *
@@ -330,8 +333,9 @@ public class SimulationService {
      * @param status status kroku (np. EXECUTED)
      * @param executedAt czas wykonania
      * @param recipeId ID przepisu
+     * @param authHeader nagłówek autoryzacji JWT
      */
-    private void notifyCookingSessionAsync(String sessionId, Integer stepNumber, String status, LocalDateTime executedAt, String recipeId) {
+    private void notifyCookingSessionAsync(String sessionId, Integer stepNumber, String status, LocalDateTime executedAt, String recipeId, String authHeader) {
         final Logger logger = LoggerFactory.getLogger(SimulationService.class);
         
         CompletableFuture.runAsync(() -> {
@@ -344,7 +348,7 @@ public class SimulationService {
                         "executedAt", executedAt.format(formatter),
                         "recipeId", recipeId
                 );
-                cookingSessionClient.notifyStepCompleted(event);
+                cookingSessionClient.notifyStepCompleted(authHeader, event);
                 logger.info("Notyfikacja wysłana do cooking-session-service: sessionId={}, stepNumber={}", sessionId, stepNumber);
             } catch (Exception e) {
                 logger.error("Błąd podczas wysyłania notyfikacji do cooking-session-service: sessionId={}, stepNumber={}", sessionId, stepNumber, e);
@@ -353,12 +357,9 @@ public class SimulationService {
     }
 
     @Transactional
-    public void completeSession(String sessionId) {
+    public void completeSession(String sessionId, String userId, String authHeader) {
         synchronized (getExecutionLock(sessionId)) {
-            SimulationSession session = simulationSessionRepository.findById(sessionId).orElse(null);
-            if (session == null) {
-                throw new SimulationSessionNotFoundException(sessionId);
-            }
+            SimulationSession session = getSessionOrThrow(sessionId, userId);
             session.setStatus(SimulationStatus.COMPLETED);
             session.setCompletedAt(LocalDateTime.now());
             simulationSessionRepository.save(session);
@@ -368,7 +369,8 @@ public class SimulationService {
                     session.getCurrentStep(),
                     "COMPLETED",
                     LocalDateTime.now(),
-                    session.getRecipeId()
+                    session.getRecipeId(),
+                    authHeader
             );
         }
     }

--- a/simulator-service/src/test/java/com/cookmate/simulator/client/CookingSessionClientTest.java
+++ b/simulator-service/src/test/java/com/cookmate/simulator/client/CookingSessionClientTest.java
@@ -33,9 +33,9 @@ class CookingSessionClientTest {
             "executedAt", "2026-05-18T12:00:00",
             "recipeId", "r-42"
         );
-        doNothing().when(cookingSessionClient).notifyStepCompleted(event);
+        doNothing().when(cookingSessionClient).notifyStepCompleted("Bearer test-token", event);
 
-        cookingSessionClient.notifyStepCompleted(event);
+        cookingSessionClient.notifyStepCompleted("Bearer test-token", event);
     }
 
     @Test
@@ -46,9 +46,9 @@ class CookingSessionClientTest {
             Collections.emptyMap(), null, new RequestTemplate()
         );
         doThrow(new FeignException.InternalServerError("500", feignRequest, null, null))
-            .when(cookingSessionClient).notifyStepCompleted(Map.of());
+            .when(cookingSessionClient).notifyStepCompleted("Bearer test-token", Map.of());
 
         assertThrows(FeignException.InternalServerError.class,
-            () -> cookingSessionClient.notifyStepCompleted(Map.of()));
+            () -> cookingSessionClient.notifyStepCompleted("Bearer test-token", Map.of()));
     }
 }

--- a/simulator-service/src/test/java/com/cookmate/simulator/controller/SimulationControllerIntegrationTest.java
+++ b/simulator-service/src/test/java/com/cookmate/simulator/controller/SimulationControllerIntegrationTest.java
@@ -54,6 +54,12 @@ class SimulationControllerIntegrationTest {
     void cleanDb() {
         stepRepo.deleteAll();
         sessionRepo.deleteAll();
+
+        org.springframework.security.oauth2.jwt.Jwt mockJwt = org.mockito.Mockito.mock(org.springframework.security.oauth2.jwt.Jwt.class);
+        org.mockito.Mockito.when(mockJwt.getSubject()).thenReturn("user");
+        org.mockito.Mockito.when(mockJwt.getClaimAsString("preferred_username")).thenReturn("test.user");
+        org.mockito.Mockito.when(mockJwt.getClaimAsMap("realm_access")).thenReturn(java.util.Map.of("roles", java.util.List.of("ROLE_USER")));
+        org.mockito.Mockito.when(jwtDecoder.decode(org.mockito.Mockito.anyString())).thenReturn(mockJwt);
     }
 
     // --- POST /api/simulator/sessions/start ---
@@ -64,6 +70,7 @@ class SimulationControllerIntegrationTest {
         mockMainSteps("52772");
 
         mockMvc.perform(post("/api/simulator/sessions/start")
+                .header("Authorization", "Bearer mock-token")
                 .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER")))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"recipeId\":\"52772\"}"))
@@ -78,6 +85,7 @@ class SimulationControllerIntegrationTest {
     @DisplayName("POST /sessions/start — 400 gdy brak recipeId")
     void startSimulation_returns400WhenNoRecipeId() throws Exception {
         mockMvc.perform(post("/api/simulator/sessions/start")
+                .header("Authorization", "Bearer mock-token")
                 .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER")))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"recipeId\":\"\"}"))
@@ -91,6 +99,7 @@ class SimulationControllerIntegrationTest {
             .thenThrow(new RuntimeException("Connection refused"));
 
         mockMvc.perform(post("/api/simulator/sessions/start")
+                .header("Authorization", "Bearer mock-token")
                 .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER")))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"recipeId\":\"52772\"}"))
@@ -106,6 +115,7 @@ class SimulationControllerIntegrationTest {
         String sessionId = createSession("52772");
 
         mockMvc.perform(post("/api/simulator/sessions/" + sessionId + "/steps/execute")
+                .header("Authorization", "Bearer mock-token")
                 .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER"))))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.success").value(true))
@@ -116,6 +126,7 @@ class SimulationControllerIntegrationTest {
     @DisplayName("POST /sessions/{id}/steps/execute — 404 dla nieistniejącej sesji")
     void executeNextStep_returns404() throws Exception {
         mockMvc.perform(post("/api/simulator/sessions/nonexistent/steps/execute")
+                .header("Authorization", "Bearer mock-token")
                 .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER"))))
             .andExpect(status().isNotFound())
             .andExpect(jsonPath("$.code").value("SIMULATION_NOT_FOUND"));
@@ -132,6 +143,7 @@ class SimulationControllerIntegrationTest {
             """;
 
         mockMvc.perform(post("/api/simulator/sessions/" + sessionId + "/step")
+                .header("Authorization", "Bearer mock-token")
                 .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER")))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(body))
@@ -145,6 +157,7 @@ class SimulationControllerIntegrationTest {
         String sessionId = createSession("52772");
 
         mockMvc.perform(post("/api/simulator/sessions/" + sessionId + "/step")
+                .header("Authorization", "Bearer mock-token")
                 .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER")))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"stepNumber\":null}"))
@@ -195,9 +208,11 @@ class SimulationControllerIntegrationTest {
         String sessionId = createSession("52772");
         // Najpierw wykonaj krok
         mockMvc.perform(post("/api/simulator/sessions/" + sessionId + "/steps/execute")
+                .header("Authorization", "Bearer mock-token")
                 .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER"))));
 
         mockMvc.perform(post("/api/simulator/sessions/" + sessionId + "/rewind?stepNumber=0")
+                .header("Authorization", "Bearer mock-token")
                 .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER"))))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.currentStep").value(0))
@@ -216,6 +231,7 @@ class SimulationControllerIntegrationTest {
     private String createSession(String recipeId) throws Exception {
         mockMainSteps(recipeId);
         MvcResult result = mockMvc.perform(post("/api/simulator/sessions/start")
+                .header("Authorization", "Bearer mock-token")
                 .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER")))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"recipeId\":\"" + recipeId + "\"}"))

--- a/simulator-service/src/test/java/com/cookmate/simulator/integration/GuidedCookingFlowTest.java
+++ b/simulator-service/src/test/java/com/cookmate/simulator/integration/GuidedCookingFlowTest.java
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -50,10 +51,19 @@ class GuidedCookingFlowTest {
     @MockitoBean
     private CookingSessionClient cookingSessionClient;
 
+    @MockitoBean
+    private JwtDecoder jwtDecoder;
+
     @BeforeEach
     void cleanDb() {
         stepRepo.deleteAll();
         sessionRepo.deleteAll();
+
+        org.springframework.security.oauth2.jwt.Jwt mockJwt = org.mockito.Mockito.mock(org.springframework.security.oauth2.jwt.Jwt.class);
+        org.mockito.Mockito.when(mockJwt.getSubject()).thenReturn("user");
+        org.mockito.Mockito.when(mockJwt.getClaimAsString("preferred_username")).thenReturn("test.user");
+        org.mockito.Mockito.when(mockJwt.getClaimAsMap("realm_access")).thenReturn(java.util.Map.of("roles", java.util.List.of("ROLE_USER")));
+        org.mockito.Mockito.when(jwtDecoder.decode(org.mockito.Mockito.anyString())).thenReturn(mockJwt);
     }
 
     @Test
@@ -67,6 +77,7 @@ class GuidedCookingFlowTest {
 
         // === 1. START — utwórz sesję ===
         MvcResult startResult = mockMvc.perform(post("/api/simulator/sessions/start")
+                .header("Authorization", "Bearer mock-token")
                 .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER")))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"recipeId\":\"52772\"}"))
@@ -90,6 +101,7 @@ class GuidedCookingFlowTest {
 
         // === 3. EXECUTE STEP 1 ===
         mockMvc.perform(post("/api/simulator/sessions/" + sessionId + "/steps/execute")
+                .header("Authorization", "Bearer mock-token")
                 .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER"))))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.success").value(true))
@@ -105,6 +117,7 @@ class GuidedCookingFlowTest {
 
         // === 5. EXECUTE STEP 2 ===
         mockMvc.perform(post("/api/simulator/sessions/" + sessionId + "/steps/execute")
+                .header("Authorization", "Bearer mock-token")
                 .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER"))))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.success").value(true))
@@ -141,6 +154,7 @@ class GuidedCookingFlowTest {
         // Start
         String sessionId = extractSessionId(
             mockMvc.perform(post("/api/simulator/sessions/start")
+                    .header("Authorization", "Bearer mock-token")
                     .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER")))
                     .contentType(MediaType.APPLICATION_JSON)
                     .content("{\"recipeId\":\"52772\"}"))
@@ -150,12 +164,14 @@ class GuidedCookingFlowTest {
 
         // Execute step 1
         mockMvc.perform(post("/api/simulator/sessions/" + sessionId + "/steps/execute")
+                .header("Authorization", "Bearer mock-token")
                 .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER"))))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.stepNumber").value(1));
 
         // Execute step 2
         mockMvc.perform(post("/api/simulator/sessions/" + sessionId + "/steps/execute")
+                .header("Authorization", "Bearer mock-token")
                 .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER"))))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.stepNumber").value(2));
@@ -174,6 +190,7 @@ class GuidedCookingFlowTest {
 
         // Re-execute step 2
         mockMvc.perform(post("/api/simulator/sessions/" + sessionId + "/steps/execute")
+                .header("Authorization", "Bearer mock-token")
                 .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER"))))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.stepNumber").value(2));
@@ -194,6 +211,7 @@ class GuidedCookingFlowTest {
 
         String sessionId = extractSessionId(
             mockMvc.perform(post("/api/simulator/sessions/start")
+                    .header("Authorization", "Bearer mock-token")
                     .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER")))
                     .contentType(MediaType.APPLICATION_JSON)
                     .content("{\"recipeId\":\"52772\"}"))
@@ -203,6 +221,7 @@ class GuidedCookingFlowTest {
 
         // processStep 1
         mockMvc.perform(post("/api/simulator/sessions/" + sessionId + "/step")
+                .header("Authorization", "Bearer mock-token")
                 .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER")))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"stepNumber\":1,\"description\":\"Exec 1\",\"durationSeconds\":5}"))
@@ -211,6 +230,7 @@ class GuidedCookingFlowTest {
 
         // processStep 2
         mockMvc.perform(post("/api/simulator/sessions/" + sessionId + "/step")
+                .header("Authorization", "Bearer mock-token")
                 .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER")))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"stepNumber\":2,\"description\":\"Exec 2\",\"durationSeconds\":5}"))
@@ -227,6 +247,7 @@ class GuidedCookingFlowTest {
     @DisplayName("Error flow: operacja na nieistniejącej sesji → 404")
     void errorFlow_sessionNotFound() throws Exception {
         mockMvc.perform(post("/api/simulator/sessions/fake-id/steps/execute")
+                .header("Authorization", "Bearer mock-token")
                 .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER"))))
             .andExpect(status().isNotFound())
             .andExpect(jsonPath("$.code").value("SIMULATION_NOT_FOUND"));

--- a/simulator-service/src/test/java/com/cookmate/simulator/service/SimulationServiceTest.java
+++ b/simulator-service/src/test/java/com/cookmate/simulator/service/SimulationServiceTest.java
@@ -57,10 +57,11 @@ class SimulationServiceTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        when(sessionRepository.findByStatus(SimulationStatus.RUNNING)).thenReturn(List.of());
+        when(sessionRepository.findByStatusAndUserId(SimulationStatus.RUNNING, "test-user-123")).thenReturn(List.of());
 
         testSession = new SimulationSession();
         testSession.setId("test-session-123");
+        testSession.setUserId("test-user-123");
         testSession.setStatus(SimulationStatus.RUNNING);
         testSession.setCurrentStep(0);
         testSession.setTotalSteps(2);
@@ -80,7 +81,7 @@ class SimulationServiceTest {
         when(sessionRepository.save(any(SimulationSession.class))).thenAnswer(invocation -> invocation.getArgument(0));
         when(stepRepository.saveAll(any())).thenAnswer(invocation -> invocation.getArgument(0));
 
-        var response = simulationService.startSession(new StartSimulationRequestDto("meal-1"));
+        var response = simulationService.startSession(new StartSimulationRequestDto("meal-1"), "test-user-123", "Bearer test-token");
 
         assertNotNull(response);
         assertEquals(SimulationStatus.RUNNING.name(), response.status());
@@ -93,7 +94,7 @@ class SimulationServiceTest {
         when(mainServiceClient.getRecipeSteps("meal-1")).thenReturn(List.of());
         assertThrows(
                 InvalidSimulationStateException.class,
-                () -> simulationService.startSession(new StartSimulationRequestDto("meal-1"))
+                () -> simulationService.startSession(new StartSimulationRequestDto("meal-1"), "test-user-123", "Bearer test-token")
         );
     }
 
@@ -104,14 +105,14 @@ class SimulationServiceTest {
         pending.setStepNumber(1);
         pending.setStatus(StepStatus.PENDING);
 
-        when(sessionRepository.findById("test-session-123")).thenReturn(Optional.of(testSession));
+        when(sessionRepository.findByIdAndUserId("test-session-123", "test-user-123")).thenReturn(Optional.of(testSession));
         when(stepRepository.findFirstBySessionIdAndStatusOrderByStepNumberAsc("test-session-123", StepStatus.PENDING))
                 .thenReturn(Optional.of(pending));
         when(stepRepository.countBySessionIdAndStatus("test-session-123", StepStatus.PENDING)).thenReturn(1L);
         when(stepRepository.save(any(SimulationStep.class))).thenAnswer(invocation -> invocation.getArgument(0));
         when(sessionRepository.save(any(SimulationSession.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-        StepExecutionResultDto response = simulationService.executeNextStep("test-session-123");
+        StepExecutionResultDto response = simulationService.executeNextStep("test-session-123", "test-user-123", "Bearer test-token");
 
         assertTrue(response.getSuccess());
         assertEquals(1, response.getStepNumber());
@@ -120,14 +121,14 @@ class SimulationServiceTest {
 
     @Test
     void testProcessStepDirectSuccess() {
-        when(sessionRepository.findById("test-session-123")).thenReturn(Optional.of(testSession));
+        when(sessionRepository.findByIdAndUserId("test-session-123", "test-user-123")).thenReturn(Optional.of(testSession));
         when(stepRepository.findBySessionIdAndStepNumber("test-session-123", 1)).thenReturn(Optional.empty());
         when(stepRepository.countBySessionIdAndStatus("test-session-123", StepStatus.PENDING)).thenReturn(1L);
         when(stepRepository.save(any(SimulationStep.class))).thenAnswer(invocation -> invocation.getArgument(0));
         when(sessionRepository.save(any(SimulationSession.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         RecipeStepRequestDto stepRequest = new RecipeStepRequestDto(1, "Test step", 1, "180C", "200g", "Note");
-        StepExecutionResultDto response = simulationService.processStep("test-session-123", stepRequest);
+        StepExecutionResultDto response = simulationService.processStep("test-session-123", stepRequest, "test-user-123", "Bearer test-token");
 
         assertTrue(response.getSuccess());
         assertEquals(1, response.getStepNumber());
@@ -135,8 +136,8 @@ class SimulationServiceTest {
 
     @Test
     void testGetStatusNotFound() {
-        when(sessionRepository.findById("unknown-session")).thenReturn(Optional.empty());
-        assertThrows(SimulationSessionNotFoundException.class, () -> simulationService.getStatus("unknown-session"));
+        when(sessionRepository.findByIdAndUserId("unknown-session", "test-user-123")).thenReturn(Optional.empty());
+        assertThrows(SimulationSessionNotFoundException.class, () -> simulationService.getStatus("unknown-session", "test-user-123"));
     }
 
     @Test
@@ -153,13 +154,13 @@ class SimulationServiceTest {
         step2.setStatus(StepStatus.EXECUTED);
         step2.setExecutedAt(LocalDateTime.now());
 
-        when(sessionRepository.findById("test-session-123")).thenReturn(Optional.of(testSession));
+        when(sessionRepository.findByIdAndUserId("test-session-123", "test-user-123")).thenReturn(Optional.of(testSession));
         when(stepRepository.findBySessionIdOrderByStepNumberAsc("test-session-123")).thenReturn(new ArrayList<>(List.of(step1, step2)));
         when(stepRepository.saveAll(any())).thenAnswer(invocation -> invocation.getArgument(0));
         when(sessionRepository.save(any(SimulationSession.class))).thenAnswer(invocation -> invocation.getArgument(0));
         when(stepRepository.countBySessionIdAndStatus("test-session-123", StepStatus.EXECUTED)).thenReturn(1L);
 
-        var status = simulationService.rewindToStep("test-session-123", 1);
+        var status = simulationService.rewindToStep("test-session-123", 1, "test-user-123");
 
         assertEquals(1, status.currentStep());
         assertEquals(SimulationStatus.RUNNING.name(), status.status());

--- a/simulator-service/src/test/java/com/cookmate/simulator/service/SimulationSessionServiceTest.java
+++ b/simulator-service/src/test/java/com/cookmate/simulator/service/SimulationSessionServiceTest.java
@@ -33,6 +33,7 @@ class SimulationSessionServiceTest {
         MockitoAnnotations.openMocks(this);
         running = new SimulationSession();
         running.setId("s-123");
+        running.setUserId("user-123");
         running.setStatus(SimulationStatus.RUNNING);
         running.setCurrentStep(0);
         running.setTotalSteps(3);
@@ -50,10 +51,11 @@ class SimulationSessionServiceTest {
             new MainServiceStepDto(2L, 2, "Step 2", null, 3, "r-42")
         );
         when(mainClient.getRecipeSteps("r-42")).thenReturn(steps);
+        when(sessionRepo.findByStatusAndUserId(SimulationStatus.RUNNING, "user-123")).thenReturn(List.of());
         when(sessionRepo.save(any())).thenAnswer(i -> i.getArgument(0));
         when(stepRepo.saveAll(any())).thenAnswer(i -> i.getArgument(0));
 
-        var resp = service.startSession(new StartSimulationRequestDto("r-42"));
+        var resp = service.startSession(new StartSimulationRequestDto("r-42"), "user-123", "Bearer test-token");
 
         assertNotNull(resp.sessionId());
         assertEquals("RUNNING", resp.status());
@@ -67,7 +69,7 @@ class SimulationSessionServiceTest {
     void startSession_throwsWhenNoSteps() {
         when(mainClient.getRecipeSteps("r-42")).thenReturn(List.of());
         assertThrows(InvalidSimulationStateException.class,
-            () -> service.startSession(new StartSimulationRequestDto("r-42")));
+            () -> service.startSession(new StartSimulationRequestDto("r-42"), "user-123", "Bearer test-token"));
     }
 
     @Test
@@ -75,7 +77,7 @@ class SimulationSessionServiceTest {
     void startSession_throwsOnMainServiceError() {
         when(mainClient.getRecipeSteps("r-42")).thenThrow(new RuntimeException("Connection refused"));
         var ex = assertThrows(MainServiceCommunicationException.class,
-            () -> service.startSession(new StartSimulationRequestDto("r-42")));
+            () -> service.startSession(new StartSimulationRequestDto("r-42"), "user-123", "Bearer test-token"));
         assertTrue(ex.getMessage().contains("r-42"));
     }
 
@@ -85,7 +87,7 @@ class SimulationSessionServiceTest {
         when(mainClient.getRecipeSteps("r-42")).thenReturn(
             List.of(new MainServiceStepDto(1L, 1, "", null, 5, "r-42")));
         assertThrows(InvalidSimulationStateException.class,
-            () -> service.startSession(new StartSimulationRequestDto("r-42")));
+            () -> service.startSession(new StartSimulationRequestDto("r-42"), "user-123", "Bearer test-token"));
     }
 
     // --- executeNextStep ---
@@ -94,14 +96,14 @@ class SimulationSessionServiceTest {
     @DisplayName("executeNextStep — wykonuje PENDING krok")
     void executeNextStep_executesPendingStep() {
         var pending = mkStep("s-123", 1, StepStatus.PENDING);
-        when(sessionRepo.findById("s-123")).thenReturn(Optional.of(running));
+        when(sessionRepo.findByIdAndUserId("s-123", "user-123")).thenReturn(Optional.of(running));
         when(stepRepo.findFirstBySessionIdAndStatusOrderByStepNumberAsc("s-123", StepStatus.PENDING))
             .thenReturn(Optional.of(pending));
         when(stepRepo.countBySessionIdAndStatus("s-123", StepStatus.PENDING)).thenReturn(2L);
         when(stepRepo.save(any())).thenAnswer(i -> i.getArgument(0));
         when(sessionRepo.save(any())).thenAnswer(i -> i.getArgument(0));
 
-        var r = service.executeNextStep("s-123");
+        var r = service.executeNextStep("s-123", "user-123", "Bearer test-token");
         assertTrue(r.getSuccess());
         assertEquals(1, r.getStepNumber());
     }
@@ -109,28 +111,28 @@ class SimulationSessionServiceTest {
     @Test
     @DisplayName("executeNextStep — false gdy brak PENDING")
     void executeNextStep_falseWhenNoPending() {
-        when(sessionRepo.findById("s-123")).thenReturn(Optional.of(running));
+        when(sessionRepo.findByIdAndUserId("s-123", "user-123")).thenReturn(Optional.of(running));
         when(stepRepo.findFirstBySessionIdAndStatusOrderByStepNumberAsc("s-123", StepStatus.PENDING))
             .thenReturn(Optional.empty());
         when(stepRepo.countBySessionIdAndStatus("s-123", StepStatus.PENDING)).thenReturn(0L);
         when(sessionRepo.save(any())).thenAnswer(i -> i.getArgument(0));
 
-        assertFalse(service.executeNextStep("s-123").getSuccess());
+        assertFalse(service.executeNextStep("s-123", "user-123", "Bearer test-token").getSuccess());
     }
 
     @Test
     @DisplayName("executeNextStep — wyjątek dla nieistniejącej sesji")
     void executeNextStep_throwsSessionNotFound() {
-        when(sessionRepo.findById("x")).thenReturn(Optional.empty());
-        assertThrows(SimulationSessionNotFoundException.class, () -> service.executeNextStep("x"));
+        when(sessionRepo.findByIdAndUserId("x", "user-123")).thenReturn(Optional.empty());
+        assertThrows(SimulationSessionNotFoundException.class, () -> service.executeNextStep("x", "user-123", "Bearer test-token"));
     }
 
     @Test
     @DisplayName("executeNextStep — wyjątek gdy sesja COMPLETED")
     void executeNextStep_throwsWhenCompleted() {
         running.setStatus(SimulationStatus.COMPLETED);
-        when(sessionRepo.findById("s-123")).thenReturn(Optional.of(running));
-        assertThrows(InvalidSimulationStateException.class, () -> service.executeNextStep("s-123"));
+        when(sessionRepo.findByIdAndUserId("s-123", "user-123")).thenReturn(Optional.of(running));
+        assertThrows(InvalidSimulationStateException.class, () -> service.executeNextStep("s-123", "user-123", "Bearer test-token"));
     }
 
     // --- processStep ---
@@ -138,13 +140,13 @@ class SimulationSessionServiceTest {
     @Test
     @DisplayName("processStep — przetwarza krok z sukcesem")
     void processStep_success() {
-        when(sessionRepo.findById("s-123")).thenReturn(Optional.of(running));
+        when(sessionRepo.findByIdAndUserId("s-123", "user-123")).thenReturn(Optional.of(running));
         when(stepRepo.findBySessionIdAndStepNumber("s-123", 1)).thenReturn(Optional.empty());
         when(stepRepo.countBySessionIdAndStatus("s-123", StepStatus.PENDING)).thenReturn(2L);
         when(stepRepo.save(any())).thenAnswer(i -> i.getArgument(0));
         when(sessionRepo.save(any())).thenAnswer(i -> i.getArgument(0));
 
-        var r = service.processStep("s-123", new RecipeStepRequestDto(1, "Heat pan", 30, "200C", "100g", "note"));
+        var r = service.processStep("s-123", new RecipeStepRequestDto(1, "Heat pan", 30, "200C", "100g", "note"), "user-123", "Bearer test-token");
         assertTrue(r.getSuccess());
         assertEquals(1, r.getStepNumber());
     }
@@ -154,19 +156,19 @@ class SimulationSessionServiceTest {
     @Test
     @DisplayName("getStatus — wyjątek dla nieistniejącej sesji")
     void getStatus_throwsNotFound() {
-        when(sessionRepo.findById("x")).thenReturn(Optional.empty());
-        assertThrows(SimulationSessionNotFoundException.class, () -> service.getStatus("x"));
+        when(sessionRepo.findByIdAndUserId("x", "user-123")).thenReturn(Optional.empty());
+        assertThrows(SimulationSessionNotFoundException.class, () -> service.getStatus("x", "user-123"));
     }
 
     @Test
     @DisplayName("getStatus — zwraca poprawny status")
     void getStatus_returnsCorrectStatus() {
         var steps = List.of(mkStep("s-123", 1, StepStatus.EXECUTED), mkStep("s-123", 2, StepStatus.PENDING));
-        when(sessionRepo.findById("s-123")).thenReturn(Optional.of(running));
+        when(sessionRepo.findByIdAndUserId("s-123", "user-123")).thenReturn(Optional.of(running));
         when(stepRepo.findBySessionIdOrderByStepNumberAsc("s-123")).thenReturn(steps);
         when(sessionRepo.save(any())).thenAnswer(i -> i.getArgument(0));
 
-        var st = service.getStatus("s-123");
+        var st = service.getStatus("s-123", "user-123");
         assertEquals("RUNNING", st.status());
         assertEquals(1, st.currentStep());
     }
@@ -178,12 +180,12 @@ class SimulationSessionServiceTest {
     void rewindToStep_rewinds() {
         var s1 = mkStep("s-123", 1, StepStatus.EXECUTED); s1.setExecutedAt(LocalDateTime.now());
         var s2 = mkStep("s-123", 2, StepStatus.EXECUTED); s2.setExecutedAt(LocalDateTime.now());
-        when(sessionRepo.findById("s-123")).thenReturn(Optional.of(running));
+        when(sessionRepo.findByIdAndUserId("s-123", "user-123")).thenReturn(Optional.of(running));
         when(stepRepo.findBySessionIdOrderByStepNumberAsc("s-123")).thenReturn(new ArrayList<>(List.of(s1, s2)));
         when(stepRepo.saveAll(any())).thenAnswer(i -> i.getArgument(0));
         when(sessionRepo.save(any())).thenAnswer(i -> i.getArgument(0));
 
-        var r = service.rewindToStep("s-123", 1);
+        var r = service.rewindToStep("s-123", 1, "user-123");
         assertEquals(1, r.currentStep());
         assertEquals("RUNNING", r.status());
     }


### PR DESCRIPTION
Closes #212 
# Izolacja sesji użytkowników oraz optymalizacja wydajności pod stress test (1000 VUs)

W ramach tego zadania rozwiązano krytyczne problemy z wydajnością, współbieżnością oraz brakiem izolacji stanów podczas testów obciążeniowych z udziałem 1000 wirtualnych użytkowników (VUs). 

---

##  Zakres wprowadzonych zmian

### 1. Izolacja sesji na poziomie użytkownika (Multi-user Session Isolation)
* **Encje i Baza Danych:** Dodano pole `userId` oraz indeksy do tabel `cooking_sessions` oraz `simulation_sessions`.
* **Warstwa biznesowa:** Przeprojektowano logikę rozpoczynania sesji (`startSession`). Dotychczasowe globalne zamykanie wszystkich sesji w systemie zastąpiono **zamykaniem poprzednich sesji wyłącznie dla danego użytkownika** (`userId` wyciąganego z JWT Keycloaka).
* **Asynchroniczny Feign Client:** Zaimplementowano bezpieczne przekazywanie tokenu autoryzacyjnego JWT z wątku kontrolera do Feign Clienta w simulator-service (działającego w wątku pobocznym `CompletableFuture.runAsync`) za pomocą jawnego nagłówka `@RequestHeader("Authorization")`.

### 2. Optymalizacja wydajności bazy danych i aplikacji (Performance Tuning)
* **Wątki wirtualne (Virtual Threads):** Włączono globalnie technologię wirtualnych wątków Java (`spring.threads.virtual.enabled: true`) we współdzielonym pliku konfiguracyjnym dla wszystkich mikroserwisów (w tym `main-service` oraz `cooking-session-service`), eliminując problem blokowania wątków platformowych Tomcat.
* **Połączenia (HikariCP & Postgres):** Zwiększono globalny limit puli połączeń `spring.datasource.hikari.maximum-pool-size` do **300** oraz limit połączeń serwera PostgreSQL w Dockerze (`max_connections`) do **800**.
* **Indeksowanie:** Utworzono indeks `idx_steps_recipe_id` na tabeli `steps` dla kolumny `recipe_id`, eliminując kosztowne przeszukiwania sekwencyjne (sequential scans) przy pobieraniu kroków przepisów.

---

##  Stress Testu (k6 – 1000 VUs)
Wyniki zostały napisane w raporcie końcowym
