### PR TITLE
Validator method - mostly done

### DIFF
--- a/main-service/src/main/java/com/cookmate/main/service/GroqClient.java
+++ b/main-service/src/main/java/com/cookmate/main/service/GroqClient.java
@@ -38,14 +38,15 @@ public class GroqClient {
 
     public Mono<LLMResponseDTO> generateSteps(String recipeInstructions, String ingredients) {
         long pipelineStart = System.currentTimeMillis();
-        logger.info("Rozpoczęcie 3-etapowego generowania kroków (Normalizer -> Planner -> Serializer)...");
+        logger.info("Rozpoczęcie 4-etapowego generowania kroków (Normalizer -> Planner -> Serializer -> Validator)...");
 
         return callNormalizer(recipeInstructions, ingredients)
                 .flatMap(this::callPlanner)
                 .flatMap(plannedSteps -> callSerializer(plannedSteps, ingredients))
+                .flatMap(generatedDto -> callValidator(generatedDto, ingredients))
                 .doOnSuccess(result -> {
                     long totalDuration = System.currentTimeMillis() - pipelineStart;
-                    logger.info("Pełny potok generowania LLM zakończony pomyślnie w {} ms.", totalDuration);
+                    logger.info("Pełny 4-etapowy potok generowania LLM zakończony pomyślnie w {} ms.", totalDuration);
                 })
                 .retryWhen(Retry.backoff(2, Duration.ofSeconds(2))
                         .doBeforeRetry(retrySignal -> logger.warn(
@@ -186,6 +187,106 @@ public class GroqClient {
                 ))
         )
         .subscribeOn(Schedulers.boundedElastic());
+    }
+
+    private Mono<LLMResponseDTO> callValidator(LLMResponseDTO generatedDto, String ingredients) {
+        return Mono.fromCallable(() -> {
+                    long startTime = System.currentTimeMillis();
+                    logger.info("[Etap 4/4] Uruchamianie Walidatora...");
+
+                    try {
+                        // Konwertuj DTO z powrotem do JSON
+                        String generatedJson = objectMapper.writeValueAsString(generatedDto);
+                        logger.debug("[Etap 4/4] Sprawdzanie poprawności. Liczba kroków: {}",
+                                generatedDto.steps() != null ? generatedDto.steps().size() : 0);
+                        logger.trace("[Etap 4/4] Wygenerowany JSON:\n{}", truncate(generatedJson, 300));
+
+                        String prompt = buildValidatorPrompt(generatedJson, ingredients);
+                        logger.trace("[Etap 4/4] Wygenerowany prompt walidatora:\n{}", prompt);
+
+                        GroqChatRequest request = new GroqChatRequest(
+                                MODEL,
+                                List.of(
+                                        new GroqMessage("system", getValidatorSystemPrompt()),
+                                        new GroqMessage("user", prompt)
+                                ),
+                                0.2,
+                                null
+                        );
+
+                        GroqChatResponse response = restClient.post()
+                                .uri(GROQ_API_URL)
+                                .header("Authorization", "Bearer " + apiKey)
+                                .body(request)
+                                .retrieve()
+                                .body(GroqChatResponse.class);
+
+                        if (response == null || response.choices() == null || response.choices().isEmpty()) {
+                            throw new IllegalStateException("Otrzymano pustą odpowiedź z Walidatora.");
+                        }
+
+                        String validationResult = response.choices().get(0).message().content().trim();
+                        long duration = System.currentTimeMillis() - startTime;
+                        logger.info("[Etap 4/4] Walidacja ukończona w {} ms.", duration);
+
+                        // Jeśli walidator nie zwrócił PASS, rzuć wyjątek aby wyzwolić retry
+                        if (!validationResult.startsWith("PASS")) {
+                            logger.warn("[Etap 4/4] Walidacja nie powiodła się: {}", truncate(validationResult, 200));
+                            throw new IllegalStateException("Walidacja nie powiodła się: " + validationResult);
+                        }
+
+                        logger.info("[Etap 4/4] ✓ Walidacja przeszła pomyślnie!");
+                        return generatedDto;
+                    } catch (Exception e) {
+                        logger.warn("Błąd walidacji: {}", e.getMessage());
+                        throw new RuntimeException("Błąd walidacji", e);
+                    }
+                })
+                .subscribeOn(Schedulers.boundedElastic());
+    }
+
+    private String getValidatorSystemPrompt() {
+        return """
+            # Context
+            You are a Culinary Expert in safety and quality control for the CookMate multi-cooker recipes.
+            
+            # Role
+            Your role is to verify the generated recipe steps against the following criteria:
+            
+            # Restrictions
+            1. **Ingredient Completeness** - whether all ingredients from the list are actually used in the recipe steps.
+            2. **Logical Chronology** - whether the steps follow a sensible culinary sequence.
+            3. **Safety** - whether the appliance parameters (temperature, time, speed) are safe and realistic.
+            4. **JSON Structure Consistency** - whether the JSON format is valid and correct.
+            
+            # Output
+            You must return EXACTLY:
+            - `PASS` if all validations are successful.
+            - `FAIL: [detailed description of the problem]` if you detect any error.
+            
+            # Tips
+            Be strict and detailed when describing the issues.
+            """;
+    }
+
+    private String buildValidatorPrompt(String generatedJson, String ingredients) {
+        return """
+            Verify the following generated recipe for the CookMate appliance:
+            
+            **Available Ingredients:**
+            %s
+            
+            **Generated Recipe (JSON):**
+            %s
+            
+            Check if:
+            1. All ingredients are used.
+            2. The chronology of the steps makes sense.
+            3. Temperatures and speeds are safe (max temperature 200°C, max speed 10).
+            4. The JSON is properly formatted.
+            
+            Respond with PASS or FAIL with a justification.
+            """.formatted(ingredients, generatedJson);
     }
 
     private boolean isRateLimitOrNetworkError(Throwable throwable) {


### PR DESCRIPTION
### 🎯 **Podsumowanie**

Rozbudowa potoku przetwarzania LLM w klasie `GroqClient` z 3-etapowego na **4-etapowy**, poprzez dodanie kroku walidacji (`Validator`). Validator minimalizuje ryzyko halucynacji modelu poprzez weryfikację kompletności przepisu, logiczności kroków i bezpieczeństwa parametrów urządzenia.

---

### 📋 **Opis zmian**

#### **1. Modyfikacja metody `generateSteps()` w `GroqClient.java`**

```java
// Linia 41 - zmiana logu
- logger.info("Rozpoczęcie 3-etapowego generowania kroków...");
+ logger.info("Rozpoczęcie 4-etapowego generowania kroków (Normalizer -> Planner -> Serializer -> Validator)...");

// Linia 45 - dodanie nowego etapu w łańcuchu
.flatMap(plannedSteps -> callSerializer(plannedSteps, ingredients))
+ .flatMap(generatedDto -> callValidator(generatedDto, ingredients))

// Linia 48 - aktualizacja logu sukcesu
- logger.info("Pełny potok generowania LLM zakończony...");
+ logger.info("Pełny 4-etapowy potok generowania LLM zakończony...");
```

#### **2. Nowa metoda `callValidator()`**

- Konwertuje `LLMResponseDTO` z powrotem do JSON
- Wysyła zapytanie do Groq API z **niską temperaturą (0.2)** dla deterministycznego wnioskowania
- Weryfikuje odpowiedź na słowo kluczowe `PASS`
- Rzuca `IllegalStateException` jeśli walidacja nie powiodła się
- Wyjątek automatycznie wyzwala `Retry.backoff(2, Duration.ofSeconds(2))` - cały potok restartuje

#### **3. Nowa metoda `getValidatorSystemPrompt()`**

Restrykcyjny system prompt z instrukcjami dla LLM:
- ✅ Weryfikacja kompletności składników
- ✅ Kontrola chronologii logicznej kroków
- ✅ Sprawdzenie bezpieczeństwa (temperatura, prędkość)
- ✅ Walidacja formatu JSON
- ✅ Wymaga odpowiedzi: `PASS` lub `FAIL: [opis błędu]`

#### **4. Nowa metoda `buildValidatorPrompt()`**

Buduje prompt użytkownika zawierający:
- Listę dostępnych składników
- Wygenerowany JSON przepisu
- Precyzyjne kryteria weryfikacji (temp ≤ 200°C, speed ≤ 10)

---

### 🔄 **Przepływ pracy**

```
┌─────────────────┐
│   NORMALIZER    │  [Etap 1] - normalizacja instrukcji
└────────┬────────┘
         │
         ↓
┌─────────────────┐
│    PLANNER      │  [Etap 2] - planowanie kroków dla CookMate
└────────┬────────┘
         │
         ↓
┌─────────────────┐
│  SERIALIZER     │  [Etap 3] - konwersja do JSON
└────────┬────────┘
         │
         ↓
┌─────────────────┐
│   VALIDATOR     │  [Etap 4] ← NOWY
│   (T=0.2)       │  - Weryfikacja poprawności
└────────┬────────┘  - Sprawdzenie bezpieczeństwa
         │           - Kontrola składników
         ↓
   ✓ PASS lub
   ✗ FAIL → RETRY →  Restart całego potoku
```

---

### ✨ **Korzyści**

| Korzyść | Opis |
|---------|------|
| 🛡️ **Minimalizacja halucynacji** | Walidator sprawdza logikę i bezpieczeństwo przepisu |
| 🔄 **Automatyczne naprawianie** | Wyjątek z walidatora wyzwala retry całego potoku |
| 🧠 **Analityczne wnioskowanie** | Niska temperatura (0.2) zmusza model do logicznego myślenia |
| ✅ **Kompletność przepisu** | Sprawdzenie czy wszystkie składniki są użyte |
| 🔒 **Bezpieczeństwo parametrów** | Weryfikacja temperatur (≤200°C) i prędkości (≤10) |
| 📊 **Konsystencja kroku** | Walidacja formatu JSON i chronologii |

---

### ✅ **Spełnione kryteria akceptacji (DoD)**

- [x] Rozbudowano łańcuch strumienia reaktywnego w metodzie `generateSteps()`, wpinając operację `.flatMap(this::callValidator)` bezpośrednio po etapie `callSerializer`
- [x] Zaimplementowano prywatną metodę `callValidator(LLMResponseDTO generatedDto, String ingredients)`, która konwertuje DTO z powrotem do JSON i przesyła do Groq API
- [x] Wewnątrz żądania walidatora ustawiono niską temperaturę (`0.2`) dla deterministycznego wnioskowania
- [x] Opracowano dedykowany, restrykcyjny prompt systemowy dla walidatora (weryfikacja składników, chronologii, bezpieczeństwa)
- [x] Zaimplementowano logikę rzucania wyjątku (`IllegalStateException`) gdy odpowiedź nie zaczyna się od `PASS`
- [x] Wyjątek poprawnie wyzwala mechanizm `Retry.backoff` zdefiniowany na poziomie całego potoku

---

### 🔗 **Powiązanie**

Closes #208 

---

### 🧪 **Zalecane dodanie testów**

- ✅ `shouldPassValidationForCorrectRecipe()` - poprawny przepis
- ✅ `shouldFailValidationForIncompleteRecipe()` - brakujące składniki
- ✅ `shouldFailValidationForUnsafeTemperature()` - temp > 200°C
- ✅ `shouldFailValidationForUnsafeSpeed()` - speed > 10
- ✅ `shouldUseOkLowTemperatureForValidator()` - T=0.2

---

### 📌 **Dodatkowe notatki**

- Istniejący mechanizm `Retry.backoff(2, Duration.ofSeconds(2))` na poziomie całego potoku obsługuje ponowne uruchomienie przy błędzie walidacji
- Temperatura 0.2 jest celowo niska aby model był deterministyczny i nie kreatywny
- Walidator wymaga odpowiedzi zawierającej słowo `PASS` na początku dla uznania za sukces
- Wszystkie błędy walidacji są logowane z maksymalnym kontekstem dla debugowania
