### PR TITLE
195 feature spis produktow na zakupy shopping list

### DIFF
--- a/meal-planner-service/MEAL_PLANNING.md
+++ b/meal-planner-service/MEAL_PLANNING.md
@@ -1,0 +1,60 @@
+# Meal Planning Flow
+
+## Generowanie planu tygodniowego
+
+1. Walidacja parametru `mealsPerDay` (1–5); wartości spoza zakresu → `IllegalArgumentException` → 400.
+2. Wywołanie `GET /api/v1/discovery/categories` przez Feign Client (`MainServiceClient.getCategories()`).
+   - Brak odpowiedzi / błąd sieci → `MainServiceCommunicationException` → 503.
+   - Pusta lista kategorii → `MealPlanGenerationException` → 500.
+3. Dla każdego z 7 dni (poniedziałek–niedziela):
+   - losowanie kategorii z pełnej listy (`Collections.shuffle` + pick),
+   - wywołanie `GET /api/v1/discovery/filter/category?c={category}` → lista posiłków tej kategorii,
+   - losowanie `mealsPerDay` posiłków z listy (bez powtórzeń w ramach dnia),
+   - jeśli kategoria nie ma posiłków — dzień dostaje pustą listę (WARN w logach).
+4. Zwrot `WeeklyPlanResponse` z listą 7 obiektów `DayPlan`, każdy z polem `day` i listą `MealItem`.
+
+```
+getCategories()
+     │
+     ▼
+dla każdego dnia (×7):
+  losuj kategorię → getMealsByCategory(category) → losuj n posiłków
+     │
+     ▼
+WeeklyPlanResponse { days: [ DayPlan, ... ] }
+```
+
+## Generowanie listy zakupów
+
+1. Klient przesyła `ShoppingListRequest` z listą `mealIds`.
+2. Dla każdego `mealId`:
+   - wywołanie `GET /api/v1/discovery/lookup/{id}` → `MealDetailListResponse`,
+   - odpowiedź `null` lub brak listy `meals` → pominięcie bez błędu.
+3. Ekstrakcja składników z każdego `MealDetailResponse`:
+   - iteracja po slotach `strIngredient1`–`strIngredient20`,
+   - slot `null` lub pusty (blank) → pominięcie,
+   - odczyt odpowiadającej miary `strMeasure1`–`strMeasure20`.
+4. Deduplicacja po nazwie składnika (case-sensitive, dokładne dopasowanie):
+   - pierwsze wystąpienie → nowy wpis w mapie (`LinkedHashMap` zachowuje kolejność wstawienia),
+   - kolejne wystąpienie tego samego składnika (z innego przepisu lub z innego slotu tego samego przepisu):
+     - miara dodawana do listy `measures`,
+     - nazwa przepisu dodawana do listy `recipes` **tylko jeśli jeszcze jej tam nie ma** (zapobiega duplikatom gdy TheMealDB wymienia ten sam składnik w dwóch slotach jednego przepisu).
+5. Zwrot `ShoppingListResponse` z listą `ShoppingListItem`:
+   - `name` — nazwa składnika,
+   - `measures` — wszystkie miary zebrane ze wszystkich przepisów,
+   - `recipes` — unikalne nazwy przepisów, które używają tego składnika.
+
+```
+mealIds: ["52772", "52884"]
+     │
+     ▼
+dla każdego id:
+  lookupById(id) → MealDetailResponse
+     │
+     ▼
+dla każdego slotu strIngredient1–20:
+  jeśli nie blank → dodaj do mapy (ingredient → accumulator)
+     │             deduplicuj recipes, zbieraj measures
+     ▼
+ShoppingListResponse { items: [ ShoppingListItem, ... ] }
+```

--- a/meal-planner-service/README.md
+++ b/meal-planner-service/README.md
@@ -1,0 +1,87 @@
+# Meal Planner Service
+
+Serwis do generowania tygodniowych planów posiłków i list zakupów na podstawie danych z TheMealDB.
+
+## Założenia
+
+- nie przechowuje danych — wszystko generowane on-the-fly przy każdym żądaniu,
+- dane o posiłkach i składnikach pobierane są z `main-service` (proxy do TheMealDB),
+- plan tygodniowy jest losowy — każde wywołanie zwraca inny wynik,
+- lista zakupów deduplikuje składniki po nazwie; zbiera wszystkie miary i przepisy dla każdego składnika,
+- endpointy wymagają uwierzytelnienia JWT (Keycloak).
+
+## Zależności
+
+| Serwis | Rola |
+|---|---|
+| `main-service` | dostarcza kategorie, listę posiłków i szczegóły składników z TheMealDB |
+| TheMealDB | zewnętrzne API (dostępne przez `main-service`) |
+| Eureka (`discovery-service`) | rejestracja i wykrywanie serwisów |
+| Keycloak | uwierzytelnianie JWT — każde żądanie wymaga Bearer tokena |
+
+## Flow
+
+1. Klient wysyła żądanie z tokenem JWT.
+2. Serwis komunikuje się z `main-service` przez Feign Client.
+3. Wynik jest budowany w pamięci i zwracany — brak zapisu do bazy.
+
+Szczegółowy opis przepływów: [MEAL_PLANNING.md](MEAL_PLANNING.md)
+
+## Endpointy
+
+| Metoda | Endpoint | Body | Opis |
+|---|---|---|---|
+| GET | `/api/planner/weekly-plan?mealsPerDay={n}` | — | generuje plan na 7 dni; `n` od 1 do 5 |
+| POST | `/api/planner/shopping-list` | `{ "mealIds": [...] }` | lista zakupów dla podanych posiłków |
+
+## Przykładowe odpowiedzi
+
+### GET /api/planner/weekly-plan?mealsPerDay=2
+
+```json
+{
+  "days": [
+    {
+      "day": "Monday",
+      "meals": [
+        { "id": "52772", "name": "Teriyaki Chicken Casserole", "thumbnailUrl": "https://..." },
+        { "id": "52884", "name": "Poutine", "thumbnailUrl": "https://..." }
+      ]
+    },
+    {
+      "day": "Tuesday",
+      "meals": [...]
+    }
+  ]
+}
+```
+
+### POST /api/planner/shopping-list
+
+```json
+// request
+{
+  "mealIds": ["52772", "52884"]
+}
+
+// response
+{
+  "items": [
+    {
+      "name": "Garlic",
+      "measures": ["2 cloves", "1 clove"],
+      "recipes": ["Teriyaki Chicken Casserole", "Poutine"]
+    },
+    {
+      "name": "Soy Sauce",
+      "measures": ["3/4 cup"],
+      "recipes": ["Teriyaki Chicken Casserole"]
+    }
+  ]
+}
+```
+
+## OpenAPI
+
+- JSON: `/v3/api-docs`
+- Swagger UI: `/swagger-ui.html`

--- a/meal-planner-service/src/main/java/com/cookmate/mealplanner/client/MainServiceClient.java
+++ b/meal-planner-service/src/main/java/com/cookmate/mealplanner/client/MainServiceClient.java
@@ -1,9 +1,11 @@
 package com.cookmate.mealplanner.client;
 
 import com.cookmate.mealplanner.dto.CategoryResponse;
+import com.cookmate.mealplanner.dto.MealDetailListResponse;
 import com.cookmate.mealplanner.dto.MealSearchResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(
@@ -17,4 +19,7 @@ public interface MainServiceClient {
 
     @GetMapping("/api/v1/discovery/filter/category")
     MealSearchResponse getMealsByCategory(@RequestParam("c") String category);
+
+    @GetMapping("/api/v1/discovery/lookup/{id}")
+    MealDetailListResponse lookupById(@PathVariable("id") String id);
 }

--- a/meal-planner-service/src/main/java/com/cookmate/mealplanner/controller/MealPlanController.java
+++ b/meal-planner-service/src/main/java/com/cookmate/mealplanner/controller/MealPlanController.java
@@ -1,7 +1,10 @@
 package com.cookmate.mealplanner.controller;
 
+import com.cookmate.mealplanner.dto.ShoppingListRequest;
+import com.cookmate.mealplanner.dto.ShoppingListResponse;
 import com.cookmate.mealplanner.dto.WeeklyPlanResponse;
 import com.cookmate.mealplanner.service.MealPlanService;
+import com.cookmate.mealplanner.service.ShoppingListService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -13,6 +16,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -25,13 +30,23 @@ import org.springframework.web.bind.annotation.RestController;
 public class MealPlanController {
 
     private final MealPlanService mealPlanService;
+    private final ShoppingListService shoppingListService;
 
     @GetMapping("/weekly-plan")
-    @Operation(summary = "Generate weekly meal plan", 
+    @Operation(summary = "Generate weekly meal plan",
                description = "Returns a 7-day meal plan with n meals per day from TheMealDB.")
-    @ApiResponse(responseCode = "200", description = "Weekly plan generated", 
+    @ApiResponse(responseCode = "200", description = "Weekly plan generated",
                  content = @Content(schema = @Schema(implementation = WeeklyPlanResponse.class)))
     public ResponseEntity<WeeklyPlanResponse> getWeeklyPlan(@RequestParam @Min(1) @Max(5) int mealsPerDay) {
         return ResponseEntity.ok(mealPlanService.generateWeeklyPlan(mealsPerDay));
+    }
+
+    @PostMapping("/shopping-list")
+    @Operation(summary = "Build shopping list",
+               description = "Returns a deduplicated shopping list for the given meal IDs.")
+    @ApiResponse(responseCode = "200", description = "Shopping list generated",
+                 content = @Content(schema = @Schema(implementation = ShoppingListResponse.class)))
+    public ResponseEntity<ShoppingListResponse> getShoppingList(@RequestBody ShoppingListRequest request) {
+        return ResponseEntity.ok(shoppingListService.buildShoppingList(request));
     }
 }

--- a/meal-planner-service/src/main/java/com/cookmate/mealplanner/dto/MealDetailListResponse.java
+++ b/meal-planner-service/src/main/java/com/cookmate/mealplanner/dto/MealDetailListResponse.java
@@ -1,0 +1,9 @@
+package com.cookmate.mealplanner.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record MealDetailListResponse(
+        @JsonProperty("meals") List<MealDetailResponse> meals
+) {}

--- a/meal-planner-service/src/main/java/com/cookmate/mealplanner/dto/MealDetailResponse.java
+++ b/meal-planner-service/src/main/java/com/cookmate/mealplanner/dto/MealDetailResponse.java
@@ -1,0 +1,55 @@
+package com.cookmate.mealplanner.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class MealDetailResponse {
+
+    @JsonProperty("idMeal") private String idMeal;
+    @JsonProperty("strMeal") private String strMeal;
+
+    @JsonProperty("strIngredient1") private String strIngredient1;
+    @JsonProperty("strIngredient2") private String strIngredient2;
+    @JsonProperty("strIngredient3") private String strIngredient3;
+    @JsonProperty("strIngredient4") private String strIngredient4;
+    @JsonProperty("strIngredient5") private String strIngredient5;
+    @JsonProperty("strIngredient6") private String strIngredient6;
+    @JsonProperty("strIngredient7") private String strIngredient7;
+    @JsonProperty("strIngredient8") private String strIngredient8;
+    @JsonProperty("strIngredient9") private String strIngredient9;
+    @JsonProperty("strIngredient10") private String strIngredient10;
+    @JsonProperty("strIngredient11") private String strIngredient11;
+    @JsonProperty("strIngredient12") private String strIngredient12;
+    @JsonProperty("strIngredient13") private String strIngredient13;
+    @JsonProperty("strIngredient14") private String strIngredient14;
+    @JsonProperty("strIngredient15") private String strIngredient15;
+    @JsonProperty("strIngredient16") private String strIngredient16;
+    @JsonProperty("strIngredient17") private String strIngredient17;
+    @JsonProperty("strIngredient18") private String strIngredient18;
+    @JsonProperty("strIngredient19") private String strIngredient19;
+    @JsonProperty("strIngredient20") private String strIngredient20;
+
+    @JsonProperty("strMeasure1") private String strMeasure1;
+    @JsonProperty("strMeasure2") private String strMeasure2;
+    @JsonProperty("strMeasure3") private String strMeasure3;
+    @JsonProperty("strMeasure4") private String strMeasure4;
+    @JsonProperty("strMeasure5") private String strMeasure5;
+    @JsonProperty("strMeasure6") private String strMeasure6;
+    @JsonProperty("strMeasure7") private String strMeasure7;
+    @JsonProperty("strMeasure8") private String strMeasure8;
+    @JsonProperty("strMeasure9") private String strMeasure9;
+    @JsonProperty("strMeasure10") private String strMeasure10;
+    @JsonProperty("strMeasure11") private String strMeasure11;
+    @JsonProperty("strMeasure12") private String strMeasure12;
+    @JsonProperty("strMeasure13") private String strMeasure13;
+    @JsonProperty("strMeasure14") private String strMeasure14;
+    @JsonProperty("strMeasure15") private String strMeasure15;
+    @JsonProperty("strMeasure16") private String strMeasure16;
+    @JsonProperty("strMeasure17") private String strMeasure17;
+    @JsonProperty("strMeasure18") private String strMeasure18;
+    @JsonProperty("strMeasure19") private String strMeasure19;
+    @JsonProperty("strMeasure20") private String strMeasure20;
+}

--- a/meal-planner-service/src/main/java/com/cookmate/mealplanner/dto/ShoppingListItem.java
+++ b/meal-planner-service/src/main/java/com/cookmate/mealplanner/dto/ShoppingListItem.java
@@ -1,0 +1,5 @@
+package com.cookmate.mealplanner.dto;
+
+import java.util.List;
+
+public record ShoppingListItem(String name, List<String> measures, List<String> recipes) {}

--- a/meal-planner-service/src/main/java/com/cookmate/mealplanner/dto/ShoppingListRequest.java
+++ b/meal-planner-service/src/main/java/com/cookmate/mealplanner/dto/ShoppingListRequest.java
@@ -1,0 +1,5 @@
+package com.cookmate.mealplanner.dto;
+
+import java.util.List;
+
+public record ShoppingListRequest(List<String> mealIds) {}

--- a/meal-planner-service/src/main/java/com/cookmate/mealplanner/dto/ShoppingListResponse.java
+++ b/meal-planner-service/src/main/java/com/cookmate/mealplanner/dto/ShoppingListResponse.java
@@ -1,0 +1,5 @@
+package com.cookmate.mealplanner.dto;
+
+import java.util.List;
+
+public record ShoppingListResponse(List<ShoppingListItem> items) {}

--- a/meal-planner-service/src/main/java/com/cookmate/mealplanner/service/ShoppingListService.java
+++ b/meal-planner-service/src/main/java/com/cookmate/mealplanner/service/ShoppingListService.java
@@ -1,0 +1,131 @@
+package com.cookmate.mealplanner.service;
+
+import com.cookmate.mealplanner.client.MainServiceClient;
+import com.cookmate.mealplanner.dto.MealDetailListResponse;
+import com.cookmate.mealplanner.dto.MealDetailResponse;
+import com.cookmate.mealplanner.dto.ShoppingListItem;
+import com.cookmate.mealplanner.dto.ShoppingListRequest;
+import com.cookmate.mealplanner.dto.ShoppingListResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class ShoppingListService {
+
+    private final MainServiceClient mainServiceClient;
+
+    public ShoppingListResponse buildShoppingList(ShoppingListRequest request) {
+        // ingredient name -> [measure, recipes]
+        Map<String, IngredientAccumulator> accumulated = new LinkedHashMap<>();
+
+        for (String mealId : request.mealIds()) {
+            MealDetailListResponse response = mainServiceClient.lookupById(mealId);
+            if (response == null || response.meals() == null) {
+                continue;
+            }
+            for (MealDetailResponse meal : response.meals()) {
+                extractIngredients(meal, accumulated);
+            }
+        }
+
+        List<ShoppingListItem> items = accumulated.entrySet().stream()
+                .map(e -> new ShoppingListItem(e.getKey(), e.getValue().measures, e.getValue().recipes))
+                .toList();
+
+        return new ShoppingListResponse(items);
+    }
+
+    private void extractIngredients(MealDetailResponse meal, Map<String, IngredientAccumulator> accumulated) {
+        String recipeName = meal.getStrMeal();
+        for (int i = 1; i <= 20; i++) {
+            String ingredient = getIngredient(meal, i);
+            if (ingredient == null || ingredient.isBlank()) {
+                continue;
+            }
+            String measure = getMeasure(meal, i);
+            String trimmedMeasure = measure != null ? measure.trim() : "";
+            accumulated.compute(ingredient, (name, acc) -> {
+                if (acc == null) {
+                    List<String> measures = new ArrayList<>();
+                    measures.add(trimmedMeasure);
+                    List<String> recipes = new ArrayList<>();
+                    recipes.add(recipeName);
+                    return new IngredientAccumulator(measures, recipes);
+                }
+                acc.measures.add(trimmedMeasure);
+                if (!acc.recipes.contains(recipeName)) {
+                    acc.recipes.add(recipeName);
+                }
+                return acc;
+            });
+        }
+    }
+
+    private String getIngredient(MealDetailResponse meal, int index) {
+        return switch (index) {
+            case 1 -> meal.getStrIngredient1();
+            case 2 -> meal.getStrIngredient2();
+            case 3 -> meal.getStrIngredient3();
+            case 4 -> meal.getStrIngredient4();
+            case 5 -> meal.getStrIngredient5();
+            case 6 -> meal.getStrIngredient6();
+            case 7 -> meal.getStrIngredient7();
+            case 8 -> meal.getStrIngredient8();
+            case 9 -> meal.getStrIngredient9();
+            case 10 -> meal.getStrIngredient10();
+            case 11 -> meal.getStrIngredient11();
+            case 12 -> meal.getStrIngredient12();
+            case 13 -> meal.getStrIngredient13();
+            case 14 -> meal.getStrIngredient14();
+            case 15 -> meal.getStrIngredient15();
+            case 16 -> meal.getStrIngredient16();
+            case 17 -> meal.getStrIngredient17();
+            case 18 -> meal.getStrIngredient18();
+            case 19 -> meal.getStrIngredient19();
+            case 20 -> meal.getStrIngredient20();
+            default -> null;
+        };
+    }
+
+    private String getMeasure(MealDetailResponse meal, int index) {
+        return switch (index) {
+            case 1 -> meal.getStrMeasure1();
+            case 2 -> meal.getStrMeasure2();
+            case 3 -> meal.getStrMeasure3();
+            case 4 -> meal.getStrMeasure4();
+            case 5 -> meal.getStrMeasure5();
+            case 6 -> meal.getStrMeasure6();
+            case 7 -> meal.getStrMeasure7();
+            case 8 -> meal.getStrMeasure8();
+            case 9 -> meal.getStrMeasure9();
+            case 10 -> meal.getStrMeasure10();
+            case 11 -> meal.getStrMeasure11();
+            case 12 -> meal.getStrMeasure12();
+            case 13 -> meal.getStrMeasure13();
+            case 14 -> meal.getStrMeasure14();
+            case 15 -> meal.getStrMeasure15();
+            case 16 -> meal.getStrMeasure16();
+            case 17 -> meal.getStrMeasure17();
+            case 18 -> meal.getStrMeasure18();
+            case 19 -> meal.getStrMeasure19();
+            case 20 -> meal.getStrMeasure20();
+            default -> null;
+        };
+    }
+
+    private static class IngredientAccumulator {
+        List<String> measures;
+        List<String> recipes;
+
+        IngredientAccumulator(List<String> measures, List<String> recipes) {
+            this.measures = measures;
+            this.recipes = recipes;
+        }
+    }
+}

--- a/meal-planner-service/src/test/java/com/cookmate/mealplanner/service/ShoppingListServiceTest.java
+++ b/meal-planner-service/src/test/java/com/cookmate/mealplanner/service/ShoppingListServiceTest.java
@@ -1,0 +1,241 @@
+package com.cookmate.mealplanner.service;
+
+import com.cookmate.mealplanner.client.MainServiceClient;
+import com.cookmate.mealplanner.dto.MealDetailListResponse;
+import com.cookmate.mealplanner.dto.MealDetailResponse;
+import com.cookmate.mealplanner.dto.ShoppingListItem;
+import com.cookmate.mealplanner.dto.ShoppingListRequest;
+import com.cookmate.mealplanner.dto.ShoppingListResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@DisplayName("ShoppingListService — unit tests")
+class ShoppingListServiceTest {
+
+    @Mock
+    private MainServiceClient mainServiceClient;
+
+    @InjectMocks
+    private ShoppingListService shoppingListService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    // --- helpers ---
+
+    private MealDetailResponse mealWith(String id, String name,
+                                        String[] ingredients, String[] measures) {
+        MealDetailResponse m = new MealDetailResponse();
+        m.setIdMeal(id);
+        m.setStrMeal(name);
+        if (ingredients.length > 0)  m.setStrIngredient1(ingredients[0]);
+        if (ingredients.length > 1)  m.setStrIngredient2(ingredients[1]);
+        if (ingredients.length > 2)  m.setStrIngredient3(ingredients[2]);
+        if (measures.length > 0)     m.setStrMeasure1(measures[0]);
+        if (measures.length > 1)     m.setStrMeasure2(measures[1]);
+        if (measures.length > 2)     m.setStrMeasure3(measures[2]);
+        return m;
+    }
+
+    private MealDetailListResponse wrap(MealDetailResponse... meals) {
+        return new MealDetailListResponse(List.of(meals));
+    }
+
+    // --- tests ---
+
+    @Test
+    @DisplayName("pusta lista mealIds zwraca pustą listę składników")
+    void emptyMealIds_returnsEmptyItems() {
+        ShoppingListResponse result = shoppingListService.buildShoppingList(new ShoppingListRequest(List.of()));
+        assertThat(result.items()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("pojedynczy posiłek — wszystkie składniki trafiają na listę")
+    void singleMeal_allIngredientsReturned() {
+        MealDetailResponse meal = mealWith("1", "Pasta",
+                new String[]{"Spaghetti", "Tomato Sauce", "Parmesan"},
+                new String[]{"200g", "100ml", "50g"});
+        when(mainServiceClient.lookupById("1")).thenReturn(wrap(meal));
+
+        ShoppingListResponse result = shoppingListService.buildShoppingList(new ShoppingListRequest(List.of("1")));
+
+        assertThat(result.items()).hasSize(3);
+        assertThat(result.items()).extracting(ShoppingListItem::name)
+                .containsExactlyInAnyOrder("Spaghetti", "Tomato Sauce", "Parmesan");
+    }
+
+    @Test
+    @DisplayName("duplikat składnika z dwóch posiłków — jeden wpis z oboma przepisami i oboma miarami")
+    void duplicateIngredient_mergesRecipesAndMeasures() {
+        MealDetailResponse meal1 = mealWith("1", "Pasta",
+                new String[]{"Garlic"}, new String[]{"2 cloves"});
+        MealDetailResponse meal2 = mealWith("2", "Soup",
+                new String[]{"Garlic"}, new String[]{"1 clove"});
+        when(mainServiceClient.lookupById("1")).thenReturn(wrap(meal1));
+        when(mainServiceClient.lookupById("2")).thenReturn(wrap(meal2));
+
+        ShoppingListResponse result = shoppingListService.buildShoppingList(
+                new ShoppingListRequest(List.of("1", "2")));
+
+        assertThat(result.items()).hasSize(1);
+        ShoppingListItem garlic = result.items().get(0);
+        assertThat(garlic.name()).isEqualTo("Garlic");
+        assertThat(garlic.measures()).containsExactly("2 cloves", "1 clove");
+        assertThat(garlic.recipes()).containsExactlyInAnyOrder("Pasta", "Soup");
+    }
+
+    @Test
+    @DisplayName("unikalny składnik — measures i recipes zawierają po jednym elemencie")
+    void uniqueIngredient_singleMeasureAndRecipe() {
+        MealDetailResponse meal = mealWith("1", "Pizza",
+                new String[]{"Mozzarella"}, new String[]{"150g"});
+        when(mainServiceClient.lookupById("1")).thenReturn(wrap(meal));
+
+        ShoppingListResponse result = shoppingListService.buildShoppingList(
+                new ShoppingListRequest(List.of("1")));
+
+        assertThat(result.items()).hasSize(1);
+        ShoppingListItem item = result.items().get(0);
+        assertThat(item.measures()).containsExactly("150g");
+        assertThat(item.recipes()).containsExactly("Pizza");
+    }
+
+    @Test
+    @DisplayName("puste/null składniki są pomijane")
+    void nullAndBlankIngredients_areSkipped() {
+        MealDetailResponse meal = new MealDetailResponse();
+        meal.setIdMeal("1");
+        meal.setStrMeal("Stew");
+        meal.setStrIngredient1("Beef");
+        meal.setStrMeasure1("300g");
+        meal.setStrIngredient2("");
+        meal.setStrIngredient3(null);
+        meal.setStrIngredient4("  ");
+        when(mainServiceClient.lookupById("1")).thenReturn(wrap(meal));
+
+        ShoppingListResponse result = shoppingListService.buildShoppingList(
+                new ShoppingListRequest(List.of("1")));
+
+        assertThat(result.items()).hasSize(1);
+        assertThat(result.items().get(0).name()).isEqualTo("Beef");
+    }
+
+    @Test
+    @DisplayName("lookupById jest wywoływany dla każdego mealId")
+    void lookupById_calledForEachMealId() {
+        MealDetailResponse meal1 = mealWith("1", "A", new String[]{"Salt"}, new String[]{"1 tsp"});
+        MealDetailResponse meal2 = mealWith("2", "B", new String[]{"Pepper"}, new String[]{"1 tsp"});
+        when(mainServiceClient.lookupById("1")).thenReturn(wrap(meal1));
+        when(mainServiceClient.lookupById("2")).thenReturn(wrap(meal2));
+
+        shoppingListService.buildShoppingList(new ShoppingListRequest(List.of("1", "2")));
+
+        verify(mainServiceClient).lookupById("1");
+        verify(mainServiceClient).lookupById("2");
+    }
+
+    @Test
+    @DisplayName("null odpowiedź z klienta jest pomijana bez błędu")
+    void nullClientResponse_isIgnoredGracefully() {
+        when(mainServiceClient.lookupById("99")).thenReturn(null);
+
+        ShoppingListResponse result = shoppingListService.buildShoppingList(
+                new ShoppingListRequest(List.of("99")));
+
+        assertThat(result.items()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("null lista posiłków w odpowiedzi jest pomijana bez błędu")
+    void nullMealsInResponse_isIgnoredGracefully() {
+        when(mainServiceClient.lookupById("99")).thenReturn(new MealDetailListResponse(null));
+
+        ShoppingListResponse result = shoppingListService.buildShoppingList(
+                new ShoppingListRequest(List.of("99")));
+
+        assertThat(result.items()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("ten sam składnik dwa razy w jednym przepisie — przepis pojawia się tylko raz w recipes, obie miary w measures")
+    void ingredientTwiceInOneMeal_recipeListedOnlyOnce_bothMeasuresCollected() {
+        MealDetailResponse meal = new MealDetailResponse();
+        meal.setIdMeal("1");
+        meal.setStrMeal("Osso Buco alla Milanese");
+        meal.setStrIngredient1("Garlic");
+        meal.setStrMeasure1("2 cloves");
+        meal.setStrIngredient2("Garlic");
+        meal.setStrMeasure2("1 clove");
+        when(mainServiceClient.lookupById("1")).thenReturn(wrap(meal));
+
+        ShoppingListResponse result = shoppingListService.buildShoppingList(
+                new ShoppingListRequest(List.of("1")));
+
+        assertThat(result.items()).hasSize(1);
+        ShoppingListItem item = result.items().get(0);
+        assertThat(item.measures()).containsExactly("2 cloves", "1 clove");
+        assertThat(item.recipes()).containsExactly("Osso Buco alla Milanese");
+    }
+
+    @Test
+    @DisplayName("składnik z dwóch różnych posiłków — obie miary są zbierane w kolejności")
+    void duplicateIngredient_collectsAllMeasuresInOrder() {
+        MealDetailResponse meal1 = mealWith("1", "Soup", new String[]{"Salt"}, new String[]{"1 tsp"});
+        MealDetailResponse meal2 = mealWith("2", "Stew", new String[]{"Salt"}, new String[]{"2 tsp"});
+        when(mainServiceClient.lookupById("1")).thenReturn(wrap(meal1));
+        when(mainServiceClient.lookupById("2")).thenReturn(wrap(meal2));
+
+        ShoppingListResponse result = shoppingListService.buildShoppingList(
+                new ShoppingListRequest(List.of("1", "2")));
+
+        assertThat(result.items()).hasSize(1);
+        assertThat(result.items().get(0).measures()).containsExactly("1 tsp", "2 tsp");
+    }
+
+    @Test
+    @DisplayName("wszystkie 20 slotów składników jest odczytywanych")
+    void allTwentyIngredientSlots_areRead() {
+        MealDetailResponse meal = new MealDetailResponse();
+        meal.setIdMeal("1");
+        meal.setStrMeal("BigMeal");
+        meal.setStrIngredient1("A1"); meal.setStrMeasure1("m1");
+        meal.setStrIngredient2("A2"); meal.setStrMeasure2("m2");
+        meal.setStrIngredient3("A3"); meal.setStrMeasure3("m3");
+        meal.setStrIngredient4("A4"); meal.setStrMeasure4("m4");
+        meal.setStrIngredient5("A5"); meal.setStrMeasure5("m5");
+        meal.setStrIngredient6("A6"); meal.setStrMeasure6("m6");
+        meal.setStrIngredient7("A7"); meal.setStrMeasure7("m7");
+        meal.setStrIngredient8("A8"); meal.setStrMeasure8("m8");
+        meal.setStrIngredient9("A9"); meal.setStrMeasure9("m9");
+        meal.setStrIngredient10("A10"); meal.setStrMeasure10("m10");
+        meal.setStrIngredient11("A11"); meal.setStrMeasure11("m11");
+        meal.setStrIngredient12("A12"); meal.setStrMeasure12("m12");
+        meal.setStrIngredient13("A13"); meal.setStrMeasure13("m13");
+        meal.setStrIngredient14("A14"); meal.setStrMeasure14("m14");
+        meal.setStrIngredient15("A15"); meal.setStrMeasure15("m15");
+        meal.setStrIngredient16("A16"); meal.setStrMeasure16("m16");
+        meal.setStrIngredient17("A17"); meal.setStrMeasure17("m17");
+        meal.setStrIngredient18("A18"); meal.setStrMeasure18("m18");
+        meal.setStrIngredient19("A19"); meal.setStrMeasure19("m19");
+        meal.setStrIngredient20("A20"); meal.setStrMeasure20("m20");
+        when(mainServiceClient.lookupById("1")).thenReturn(wrap(meal));
+
+        ShoppingListResponse result = shoppingListService.buildShoppingList(
+                new ShoppingListRequest(List.of("1")));
+
+        assertThat(result.items()).hasSize(20);
+    }
+}


### PR DESCRIPTION
## Opis
Implementacja endpointu listy zakupów w `meal-planner-service`.

## Zmiany
- Nowy endpoint `POST /api/planner/shopping-list` przyjmujący listę ID przepisów
- Pobieranie szczegółów przepisów z `main-service` przez Feign (`lookupById`)
- Ekstrakcja składników z pól `strIngredient1-20` i `strMeasure1-20` z TheMealDB
- Deduplikacja składników po nazwie — ten sam składnik z wielu przepisów łączony w jedną pozycję
- Lista miar (`measures`) zamiast jednej miary — zachowane wszystkie ilości gdy składnik występuje wielokrotnie
- 30 testów jednostkowych (10 nowych dla ShoppingListService)
- Dokumentacja: README.md i MEAL_PLANNING.md

## Ograniczenia i plany na przyszłość
- Brak persystencji — lista zakupów generowana na żywo, nie zapisywana
- Brak powiązania z użytkownikiem — do dodania po integracji JWT gateway
- Deduplikacja prosta (po nazwie) — w przyszłości warto rozważyć inteligentne sumowanie miar przez LLM (Groq)
- Warto rozważyć integrację z weekly meal planner — automatyczne generowanie listy zakupów z wygenerowanego planu tygodniowego

Closes #195