### PR TITLE
210 feat dodanie funkcjonalności ulubionych przepisów favorites w main service

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -87,7 +87,10 @@ function AppContent() {
         </div>
 
         <div className='pt-8'>
-          <RecipeGallery onStartCooking={handleStartCooking} />
+          <RecipeGallery 
+            onStartCooking={handleStartCooking} 
+            onRequireLogin={() => setShowLoginModal(true)} 
+          />
         </div>
       </main>
       <Footer />
@@ -112,7 +115,7 @@ function AppContent() {
               <div className="text-5xl mb-4">🍳</div>
               <h2 className="text-2xl font-bold text-stone-800 mb-2">Login Required</h2>
               <p className="text-stone-600">
-                To start guided cooking and save your progress, you need to log in.
+                To use this feature and save your progress, you need to log in.
               </p>
             </div>
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -97,8 +97,17 @@ function AppContent() {
 
       {/* ── Login Modal ── */}
       {showLoginModal && (
-        <div className="fixed inset-0 z-[100] flex items-center justify-center bg-stone-900/50 backdrop-blur-sm p-4">
-          <div className="bg-white rounded-2xl p-8 max-w-md w-full shadow-2xl relative">
+        <div 
+          className="fixed inset-0 z-[100] flex items-center justify-center bg-stone-900/50 backdrop-blur-sm p-4"
+          onClick={() => {
+            localStorage.removeItem('pendingRecipeId');
+            setShowLoginModal(false);
+          }}
+        >
+          <div 
+            className="bg-white rounded-2xl p-8 max-w-md w-full shadow-2xl relative"
+            onClick={(e) => e.stopPropagation()}
+          >
             <button
               onClick={() => {
                 localStorage.removeItem('pendingRecipeId');

--- a/frontend/src/components/ExpandedRecipeCard.tsx
+++ b/frontend/src/components/ExpandedRecipeCard.tsx
@@ -1,13 +1,16 @@
 import { useMealDetails } from '../hooks/useMealDetails';
 import { useCheckFavorite, useAddFavorite, useRemoveFavorite } from '../hooks/useFavorites';
+import { useAuth } from '../context/AuthContext';
 
 interface ExpandedRecipeCardProps {
   id: string | null;
   onClose: () => void;
   onStartCooking?: (id: string) => void;
+  onRequireLogin?: () => void;
 }
 
-export function ExpandedRecipeCard({ id, onClose, onStartCooking }: ExpandedRecipeCardProps) {
+export function ExpandedRecipeCard({ id, onClose, onStartCooking, onRequireLogin }: ExpandedRecipeCardProps) {
+  const { isAuthenticated } = useAuth();
   const { data, isLoading, isError } = useMealDetails(id);
   const { data: isFav } = useCheckFavorite(id);
   const { mutate: addFav } = useAddFavorite();
@@ -112,6 +115,10 @@ export function ExpandedRecipeCard({ id, onClose, onStartCooking }: ExpandedReci
                 <button
                   onClick={(e) => {
                     e.stopPropagation();
+                    if (!isAuthenticated) {
+                      onRequireLogin?.();
+                      return;
+                    }
                     if (isFav) {
                       removeFav(id);
                     } else {

--- a/frontend/src/components/ExpandedRecipeCard.tsx
+++ b/frontend/src/components/ExpandedRecipeCard.tsx
@@ -1,4 +1,5 @@
 import { useMealDetails } from '../hooks/useMealDetails';
+import { useCheckFavorite, useAddFavorite, useRemoveFavorite } from '../hooks/useFavorites';
 
 interface ExpandedRecipeCardProps {
   id: string | null;
@@ -8,6 +9,9 @@ interface ExpandedRecipeCardProps {
 
 export function ExpandedRecipeCard({ id, onClose, onStartCooking }: ExpandedRecipeCardProps) {
   const { data, isLoading, isError } = useMealDetails(id);
+  const { data: isFav } = useCheckFavorite(id);
+  const { mutate: addFav } = useAddFavorite();
+  const { mutate: removeFav } = useRemoveFavorite();
 
   if (!id) return null;
 
@@ -102,6 +106,24 @@ export function ExpandedRecipeCard({ id, onClose, onStartCooking }: ExpandedReci
                   className="inline-flex items-center gap-2 px-6 py-2.5 bg-gradient-to-r from-amber-500 to-orange-500 text-white font-bold rounded-full shadow-md hover:shadow-lg hover:scale-105 transition-all duration-300"
                 >
                   Start cooking
+                </button>
+              )}
+              {id && (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    if (isFav) {
+                      removeFav(id);
+                    } else {
+                      addFav({ recipeId: id, request: { recipeTitle: meal.strMeal, imageUrl: meal.strMealThumb } });
+                    }
+                  }}
+                  className={`inline-flex items-center gap-2 px-6 py-2.5 font-bold rounded-full border shadow-sm transition-all duration-300 ${isFav ? 'bg-red-50 text-red-600 border-red-200 hover:bg-red-100' : 'bg-white text-stone-600 border-stone-200 hover:bg-stone-50'}`}
+                >
+                  <svg xmlns="http://www.w3.org/2000/svg" className={`h-5 w-5 ${isFav ? 'fill-current' : 'fill-transparent'}`} viewBox="0 0 24 24" stroke="currentColor" strokeWidth={isFav ? 0 : 2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+                  </svg>
+                  {isFav ? 'Remove from favorites' : 'Add to favorites'}
                 </button>
               )}
               {meal.strYoutube && (

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect } from 'react';
 import { SourceToggle } from './SourceToggle';
 import { useAuth } from '../context/AuthContext';
+import { useRecipeStore } from '../store/useRecipeStore';
 
 interface HeaderProps {
   onHomeClick?: () => void;
@@ -50,6 +51,7 @@ export function Header({ onHomeClick }: HeaderProps) {
               if (!isAuthenticated) {
                 login();
               } else {
+                useRecipeStore.getState().setSource('FAVORITES');
                 onHomeClick?.();
               }
             }}

--- a/frontend/src/components/RecipeCard.tsx
+++ b/frontend/src/components/RecipeCard.tsx
@@ -1,4 +1,5 @@
 import { useCheckFavorite, useAddFavorite, useRemoveFavorite } from '../hooks/useFavorites';
+import { useAuth } from '../context/AuthContext';
 
 export interface RecipeCardProps {
   id: string;
@@ -6,11 +7,13 @@ export interface RecipeCardProps {
   time?: number;
   category?: string;
   imageUrl?: string;
-  onClick?: (id: string) => void;
+  onClick: (id: string) => void;
   isPending?: boolean;
+  onRequireLogin?: () => void;
 }
 
-export function RecipeCard({ id, name, time, category, imageUrl, onClick, isPending }: RecipeCardProps) {
+export function RecipeCard({ id, name, time, category, imageUrl, onClick, isPending, onRequireLogin }: RecipeCardProps) {
+  const { isAuthenticated } = useAuth();
   // Placeholder image if none provided
   const imgSource = imageUrl || 'https://images.unsplash.com/photo-1546069901-ba9599a7e63c?ixlib=rb-4.0.3&auto=format&fit=crop&w=500&q=60';
   
@@ -45,6 +48,10 @@ export function RecipeCard({ id, name, time, category, imageUrl, onClick, isPend
         <button
           onClick={(e) => {
             e.stopPropagation();
+            if (!isAuthenticated) {
+              onRequireLogin?.();
+              return;
+            }
             if (isFav) {
               removeFav(id);
             } else {

--- a/frontend/src/components/RecipeCard.tsx
+++ b/frontend/src/components/RecipeCard.tsx
@@ -1,3 +1,5 @@
+import { useCheckFavorite, useAddFavorite, useRemoveFavorite } from '../hooks/useFavorites';
+
 export interface RecipeCardProps {
   id: string;
   name: string;
@@ -11,6 +13,10 @@ export interface RecipeCardProps {
 export function RecipeCard({ id, name, time, category, imageUrl, onClick, isPending }: RecipeCardProps) {
   // Placeholder image if none provided
   const imgSource = imageUrl || 'https://images.unsplash.com/photo-1546069901-ba9599a7e63c?ixlib=rb-4.0.3&auto=format&fit=crop&w=500&q=60';
+  
+  const { data: isFav } = useCheckFavorite(id);
+  const { mutate: addFav } = useAddFavorite();
+  const { mutate: removeFav } = useRemoveFavorite();
 
   return (
     <div 
@@ -36,6 +42,28 @@ export function RecipeCard({ id, name, time, category, imageUrl, onClick, isPend
             {category}
           </div>
         )}
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            if (isFav) {
+              removeFav(id);
+            } else {
+              addFav({ recipeId: id, request: { recipeTitle: name, imageUrl: imgSource } });
+            }
+          }}
+          className="absolute top-3 right-3 p-2 rounded-full bg-white/80 backdrop-blur-sm shadow-sm hover:bg-white hover:scale-110 transition-all z-20 group"
+          title={isFav ? "Remove from favorites" : "Add to favorites"}
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className={`h-5 w-5 ${isFav ? 'text-red-500 fill-current' : 'text-stone-400 fill-transparent'} group-hover:text-red-500 transition-colors`}
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={isFav ? 0 : 2}
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+          </svg>
+        </button>
       </div>
       <div className="p-5 flex flex-col flex-grow">
         <h3 className="text-xl font-bold text-stone-800 line-clamp-2 leading-tight mb-2 group-hover:text-amber-600 transition-colors">

--- a/frontend/src/components/RecipeGallery.tsx
+++ b/frontend/src/components/RecipeGallery.tsx
@@ -127,7 +127,7 @@ const MOCK_RECIPES = [
   { id: '6', name: 'Grilled Salmon with Asparagus', time: 25, category: 'Seafood', imageUrl: 'https://images.unsplash.com/photo-1467003909585-2f8a72700288?ixlib=rb-4.0.3&auto=format&fit=crop&w=500&q=60' },
 ];
 
-export function RecipeGallery({ onStartCooking }: { onStartCooking?: (recipeId: string) => void }) {
+export function RecipeGallery({ onStartCooking, onRequireLogin }: { onStartCooking?: (recipeId: string) => void, onRequireLogin?: () => void }) {
   const { source, searchQuery, setSearchQuery } = useRecipeStore();
   const { data: activeSession } = useGlobalActiveSession();
   const [searchInput, setSearchInput] = useState(searchQuery);
@@ -289,6 +289,7 @@ export function RecipeGallery({ onStartCooking }: { onStartCooking?: (recipeId: 
                   id={recipe.id} 
                   onClose={() => handleSelect(null)}
                   onStartCooking={onStartCooking}
+                  onRequireLogin={onRequireLogin}
                 />
               </div>
             ) : (
@@ -299,6 +300,7 @@ export function RecipeGallery({ onStartCooking }: { onStartCooking?: (recipeId: 
                 category={recipe.category}
                 imageUrl={recipe.imageUrl}
                 onClick={handleSelect}
+                onRequireLogin={onRequireLogin}
               />
             )}
           </div>
@@ -315,6 +317,7 @@ export function RecipeGallery({ onStartCooking }: { onStartCooking?: (recipeId: 
                   id={meal.idMeal} 
                   onClose={() => handleSelect(null)}
                   onStartCooking={onStartCooking}
+                  onRequireLogin={onRequireLogin}
                 />
               </div>
             ) : (
@@ -325,6 +328,7 @@ export function RecipeGallery({ onStartCooking }: { onStartCooking?: (recipeId: 
                 imageUrl={meal.strMealThumb}
                 onClick={handleSelect}
                 isPending={pendingRecipeId === meal.idMeal}
+                onRequireLogin={onRequireLogin}
               />
             )}
           </div>

--- a/frontend/src/components/RecipeGallery.tsx
+++ b/frontend/src/components/RecipeGallery.tsx
@@ -10,6 +10,7 @@ import { useGlobalActiveSession } from '../hooks/useGlobalActiveSession';
 import { completeSimulationSession, completeCookingSession } from '../services/simulatorApi';
 import { useQueryClient } from '@tanstack/react-query';
 import { useSimulationProgress } from '../hooks/useSimulationProgress';
+import { useFavorites } from '../hooks/useFavorites';
 
 function ActiveCookingCard({ 
   recipeId, 
@@ -136,6 +137,7 @@ export function RecipeGallery({ onStartCooking }: { onStartCooking?: (recipeId: 
   const cols = useGridCols();
   
   const { data: listData, isLoading: isListLoading, isError: isListError } = useDiscoveryRecipes(searchQuery);
+  const { data: favoritesData, isLoading: isFavoritesLoading, isError: isFavoritesError, fetchNextPage, hasNextPage, isFetchingNextPage } = useFavorites();
   
   const fetchId = pendingRecipeId || selectedRecipeId;
   const { isLoading: isDetailsLoading } = useMealDetails(fetchId);
@@ -224,6 +226,9 @@ export function RecipeGallery({ onStartCooking }: { onStartCooking?: (recipeId: 
 
   const sortedMockRecipes = reorderToRowStart(MOCK_RECIPES, selectedRecipeId, 'id');
   const sortedDiscoveryMeals = reorderToRowStart(listData?.meals || [], selectedRecipeId, 'idMeal');
+  
+  const allFavorites = favoritesData ? favoritesData.pages.flatMap(page => page.content) : [];
+  const sortedFavorites = reorderToRowStart(allFavorites, selectedRecipeId, 'recipeId');
 
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
@@ -324,7 +329,61 @@ export function RecipeGallery({ onStartCooking }: { onStartCooking?: (recipeId: 
             )}
           </div>
         ))}
+
+        {source === 'FAVORITES' && isFavoritesLoading && (
+          <div className="col-span-full text-center text-stone-500 py-10">Loading favorites...</div>
+        )}
+
+        {source === 'FAVORITES' && isFavoritesError && (
+          <div className="col-span-full text-center text-red-500 py-10">Failed to load favorites.</div>
+        )}
+
+        {source === 'FAVORITES' && sortedFavorites.map((fav) => (
+          <div 
+            key={fav.recipeId} 
+            className={selectedRecipeId === fav.recipeId ? 'col-span-full' : ''}
+          >
+            {selectedRecipeId === fav.recipeId ? (
+              <div ref={expandedRef}>
+                <ExpandedRecipeCard 
+                  id={fav.recipeId} 
+                  onClose={() => handleSelect(null)}
+                  onStartCooking={onStartCooking}
+                />
+              </div>
+            ) : (
+              <RecipeCard
+                id={fav.recipeId}
+                name={fav.recipeTitle}
+                imageUrl={fav.imageUrl}
+                onClick={handleSelect}
+                isPending={pendingRecipeId === fav.recipeId}
+              />
+            )}
+          </div>
+        ))}
       </div>
+      
+      {/* Load More Pagination for Favorites */}
+      {source === 'FAVORITES' && hasNextPage && (
+        <div className="flex justify-center items-center mt-12 gap-2">
+          <button 
+            onClick={() => fetchNextPage()} 
+            disabled={isFetchingNextPage}
+            className="px-6 py-3 bg-white border border-stone-200 rounded-xl text-stone-700 font-bold hover:bg-stone-50 disabled:opacity-50 shadow-sm transition-all"
+          >
+            {isFetchingNextPage ? 'Loading more...' : 'Load More'}
+          </button>
+        </div>
+      )}
+      {source === 'FAVORITES' && !hasNextPage && sortedFavorites.length > 0 && (
+        <div className="flex justify-center items-center mt-12">
+          <p className="text-stone-500 font-medium">You have reached the end of your favorites.</p>
+        </div>
+      )}
+      {source === 'FAVORITES' && sortedFavorites.length === 0 && !isFavoritesLoading && !isFavoritesError && (
+        <div className="col-span-full text-center text-stone-500 py-10">You have no favorite recipes yet. Start discovering!</div>
+      )}
       
       {/* Static Pagination for Prototype LOCAL */}
       {source === 'LOCAL' && (

--- a/frontend/src/components/SourceToggle.tsx
+++ b/frontend/src/components/SourceToggle.tsx
@@ -22,6 +22,12 @@ export function SourceToggle({ className = '' }: { className?: string }) {
           My Recipes
         </button>
         <button 
+          onClick={() => setSource('FAVORITES')}
+          className={`px-4 py-1.5 rounded-full text-sm font-semibold transition-all duration-300 ${source === 'FAVORITES' ? 'bg-white text-orange-600 shadow-sm' : 'text-white/80 hover:text-white hover:bg-white/10'}`}
+        >
+          Favorites
+        </button>
+        <button 
           onClick={() => setSource('DISCOVERY')}
           className={`px-4 py-1.5 rounded-full text-sm font-semibold transition-all duration-300 ${source === 'DISCOVERY' ? 'bg-white text-orange-600 shadow-sm' : 'text-white/80 hover:text-white hover:bg-white/10'}`}
         >

--- a/frontend/src/components/SourceToggle.tsx
+++ b/frontend/src/components/SourceToggle.tsx
@@ -1,10 +1,12 @@
 import { useEffect } from 'react';
 import { useRecipeStore } from '../store/useRecipeStore';
 import { useGlobalActiveSession } from '../hooks/useGlobalActiveSession';
+import { useAuth } from '../context/AuthContext';
 
 export function SourceToggle({ className = '' }: { className?: string }) {
   const { source, setSource } = useRecipeStore();
   const { data: activeSession } = useGlobalActiveSession();
+  const { isAuthenticated, login } = useAuth();
 
   useEffect(() => {
     if (source === 'ACTIVE' && !activeSession) {
@@ -22,7 +24,13 @@ export function SourceToggle({ className = '' }: { className?: string }) {
           My Recipes
         </button>
         <button 
-          onClick={() => setSource('FAVORITES')}
+          onClick={() => {
+            if (!isAuthenticated) {
+              login();
+            } else {
+              setSource('FAVORITES');
+            }
+          }}
           className={`px-4 py-1.5 rounded-full text-sm font-semibold transition-all duration-300 ${source === 'FAVORITES' ? 'bg-white text-orange-600 shadow-sm' : 'text-white/80 hover:text-white hover:bg-white/10'}`}
         >
           Favorites

--- a/frontend/src/hooks/useFavorites.ts
+++ b/frontend/src/hooks/useFavorites.ts
@@ -1,8 +1,9 @@
 import { useInfiniteQuery, useMutation, useQueryClient, useQuery } from '@tanstack/react-query';
 import { fetchFavorites, addFavorite, removeFavorite, checkFavorite } from '../services/favoritesApi';
 import type { FavoriteRecipeAddRequest, PaginatedFavorites } from '../services/favoritesApi';
-
+import { useAuth } from '../context/AuthContext';
 export const useFavorites = () => {
+  const { isAuthenticated } = useAuth();
   return useInfiniteQuery<PaginatedFavorites, Error>({
     queryKey: ['favorites'],
     queryFn: ({ pageParam = 0 }) => fetchFavorites(pageParam as number, 12),
@@ -11,6 +12,7 @@ export const useFavorites = () => {
       return lastPage.number + 1;
     },
     initialPageParam: 0,
+    enabled: isAuthenticated,
   });
 };
 
@@ -37,10 +39,11 @@ export const useRemoveFavorite = () => {
 };
 
 export const useCheckFavorite = (recipeId: string | null) => {
+  const { isAuthenticated } = useAuth();
   return useQuery({
     queryKey: ['favoriteCheck', recipeId],
     queryFn: () => recipeId ? checkFavorite(recipeId) : Promise.resolve(false),
-    enabled: !!recipeId,
+    enabled: !!recipeId && isAuthenticated,
     retry: false,
   });
 };

--- a/frontend/src/hooks/useFavorites.ts
+++ b/frontend/src/hooks/useFavorites.ts
@@ -1,0 +1,46 @@
+import { useInfiniteQuery, useMutation, useQueryClient, useQuery } from '@tanstack/react-query';
+import { fetchFavorites, addFavorite, removeFavorite, checkFavorite } from '../services/favoritesApi';
+import type { FavoriteRecipeAddRequest, PaginatedFavorites } from '../services/favoritesApi';
+
+export const useFavorites = () => {
+  return useInfiniteQuery<PaginatedFavorites, Error>({
+    queryKey: ['favorites'],
+    queryFn: ({ pageParam = 0 }) => fetchFavorites(pageParam as number, 12),
+    getNextPageParam: (lastPage) => {
+      if (lastPage.last) return undefined;
+      return lastPage.number + 1;
+    },
+    initialPageParam: 0,
+  });
+};
+
+export const useAddFavorite = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ recipeId, request }: { recipeId: string, request: FavoriteRecipeAddRequest }) => addFavorite(recipeId, request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['favorites'] });
+      queryClient.invalidateQueries({ queryKey: ['favoriteCheck'] });
+    },
+  });
+};
+
+export const useRemoveFavorite = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (recipeId: string) => removeFavorite(recipeId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['favorites'] });
+      queryClient.invalidateQueries({ queryKey: ['favoriteCheck'] });
+    },
+  });
+};
+
+export const useCheckFavorite = (recipeId: string | null) => {
+  return useQuery({
+    queryKey: ['favoriteCheck', recipeId],
+    queryFn: () => recipeId ? checkFavorite(recipeId) : Promise.resolve(false),
+    enabled: !!recipeId,
+    retry: false,
+  });
+};

--- a/frontend/src/services/favoritesApi.ts
+++ b/frontend/src/services/favoritesApi.ts
@@ -1,0 +1,69 @@
+import { authFetch } from './authFetch';
+
+const API_BASE_URL = '/api';
+
+export interface FavoriteRecipeAddRequest {
+  recipeTitle: string;
+  imageUrl?: string;
+}
+
+export interface FavoriteRecipeDTO {
+  id: number;
+  recipeId: string;
+  recipeTitle: string;
+  imageUrl?: string;
+  addedAt: string;
+}
+
+export interface PaginatedFavorites {
+  content: FavoriteRecipeDTO[];
+  pageable: any;
+  last: boolean;
+  totalElements: number;
+  totalPages: number;
+  size: number;
+  number: number;
+  first: boolean;
+  numberOfElements: number;
+  empty: boolean;
+}
+
+export const fetchFavorites = async (page: number = 0, size: number = 10): Promise<PaginatedFavorites> => {
+  const response = await authFetch(`${API_BASE_URL}/recipes/favorites?page=${page}&size=${size}`);
+  if (!response.ok) {
+    throw new Error('Failed to fetch favorites');
+  }
+  return response.json();
+};
+
+export const addFavorite = async (recipeId: string, request: FavoriteRecipeAddRequest): Promise<FavoriteRecipeDTO> => {
+  const response = await authFetch(`${API_BASE_URL}/recipes/${recipeId}/favorite`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(request),
+  });
+  if (!response.ok) {
+    throw new Error('Failed to add favorite');
+  }
+  return response.json();
+};
+
+export const removeFavorite = async (recipeId: string): Promise<void> => {
+  const response = await authFetch(`${API_BASE_URL}/recipes/${recipeId}/favorite`, {
+    method: 'DELETE',
+  });
+  if (!response.ok) {
+    throw new Error('Failed to remove favorite');
+  }
+};
+
+export const checkFavorite = async (recipeId: string): Promise<boolean> => {
+  const response = await authFetch(`${API_BASE_URL}/recipes/${recipeId}/favorite/check`);
+  if (!response.ok) {
+    if (response.status === 401 || response.status === 403) return false;
+    throw new Error('Failed to check favorite');
+  }
+  return response.json();
+};

--- a/frontend/src/store/useRecipeStore.ts
+++ b/frontend/src/store/useRecipeStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 
-export type RecipeSource = 'LOCAL' | 'DISCOVERY' | 'ACTIVE';
+export type RecipeSource = 'LOCAL' | 'DISCOVERY' | 'ACTIVE' | 'FAVORITES';
 
 interface RecipeState {
   source: RecipeSource;

--- a/keycloak/realm-export.json
+++ b/keycloak/realm-export.json
@@ -12,11 +12,35 @@
   "requiredCredentials": [
     "password"
   ],
-  "defaultRoles": [
-    "ROLE_USER"
-  ],
+  "defaultRole": {
+    "name": "default-roles-cookmate",
+    "description": "${role_default-roles}",
+    "composite": true,
+    "clientRole": false,
+    "containerId": "cookmate"
+  },
   "roles": {
     "realm": [
+      {
+        "name": "default-roles-cookmate",
+        "description": "${role_default-roles}",
+        "composite": true,
+        "clientRole": false,
+        "containerId": "cookmate",
+        "composites": {
+          "realm": [
+            "offline_access",
+            "uma_authorization",
+            "ROLE_USER"
+          ],
+          "client": {
+            "account": [
+              "manage-account",
+              "view-profile"
+            ]
+          }
+        }
+      },
       {
         "name": "ROLE_USER",
         "description": "Default application user role",

--- a/main-service/src/main/java/com/cookmate/main/controller/FavoriteRecipeController.java
+++ b/main-service/src/main/java/com/cookmate/main/controller/FavoriteRecipeController.java
@@ -1,0 +1,70 @@
+package com.cookmate.main.controller;
+
+import com.cookmate.main.dto.FavoriteRecipeAddRequest;
+import com.cookmate.main.dto.FavoriteRecipeDTO;
+import com.cookmate.main.service.FavoriteRecipeService;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/recipes")
+@Validated
+public class FavoriteRecipeController {
+
+    private final FavoriteRecipeService favoriteRecipeService;
+
+    public FavoriteRecipeController(FavoriteRecipeService favoriteRecipeService) {
+        this.favoriteRecipeService = favoriteRecipeService;
+    }
+
+    @GetMapping("/favorites")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    public ResponseEntity<Page<FavoriteRecipeDTO>> getFavorites(
+            JwtAuthenticationToken jwt,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        
+        String userId = jwt.getName();
+        return ResponseEntity.ok(favoriteRecipeService.getUserFavorites(userId, page, size));
+    }
+
+    @PostMapping("/{recipeId}/favorite")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    public ResponseEntity<FavoriteRecipeDTO> addFavorite(
+            JwtAuthenticationToken jwt,
+            @PathVariable String recipeId,
+            @Valid @RequestBody FavoriteRecipeAddRequest request) {
+        
+        String userId = jwt.getName();
+        FavoriteRecipeDTO favorite = favoriteRecipeService.addFavorite(userId, recipeId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(favorite);
+    }
+
+    @GetMapping("/{recipeId}/favorite/check")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    public ResponseEntity<Boolean> checkFavorite(
+            JwtAuthenticationToken jwt,
+            @PathVariable String recipeId) {
+        
+        String userId = jwt.getName();
+        boolean isFavorite = favoriteRecipeService.isFavorite(userId, recipeId);
+        return ResponseEntity.ok(isFavorite);
+    }
+
+    @DeleteMapping("/{recipeId}/favorite")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    public ResponseEntity<Void> removeFavorite(
+            JwtAuthenticationToken jwt,
+            @PathVariable String recipeId) {
+        
+        String userId = jwt.getName();
+        favoriteRecipeService.removeFavorite(userId, recipeId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/main-service/src/main/java/com/cookmate/main/dto/FavoriteRecipeAddRequest.java
+++ b/main-service/src/main/java/com/cookmate/main/dto/FavoriteRecipeAddRequest.java
@@ -1,0 +1,9 @@
+package com.cookmate.main.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record FavoriteRecipeAddRequest(
+    @NotBlank(message = "Recipe title cannot be blank")
+    String recipeTitle,
+    String imageUrl
+) {}

--- a/main-service/src/main/java/com/cookmate/main/dto/FavoriteRecipeDTO.java
+++ b/main-service/src/main/java/com/cookmate/main/dto/FavoriteRecipeDTO.java
@@ -1,0 +1,11 @@
+package com.cookmate.main.dto;
+
+import java.time.LocalDateTime;
+
+public record FavoriteRecipeDTO(
+    Long id,
+    String recipeId,
+    String recipeTitle,
+    String imageUrl,
+    LocalDateTime addedAt
+) {}

--- a/main-service/src/main/java/com/cookmate/main/model/FavoriteRecipe.java
+++ b/main-service/src/main/java/com/cookmate/main/model/FavoriteRecipe.java
@@ -1,0 +1,93 @@
+package com.cookmate.main.model;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import java.time.LocalDateTime;
+
+/**
+ * Entity representing a user's favorite recipe.
+ */
+@Entity
+@Table(
+    name = "user_favorite_recipes",
+    uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"user_id", "recipe_id"})
+    }
+)
+public class FavoriteRecipe {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank
+    @Column(name = "user_id", nullable = false)
+    private String userId;
+
+    @NotBlank
+    @Column(name = "recipe_id", nullable = false)
+    private String recipeId;
+
+    @Column(name = "recipe_title")
+    private String recipeTitle;
+
+    @Column(name = "image_url")
+    private String imageUrl;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+    }
+
+    public FavoriteRecipe() {}
+
+    public FavoriteRecipe(String userId, String recipeId, String recipeTitle, String imageUrl) {
+        this.userId = userId;
+        this.recipeId = recipeId;
+        this.recipeTitle = recipeTitle;
+        this.imageUrl = imageUrl;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public String getRecipeId() {
+        return recipeId;
+    }
+
+    public void setRecipeId(String recipeId) {
+        this.recipeId = recipeId;
+    }
+
+    public String getRecipeTitle() {
+        return recipeTitle;
+    }
+
+    public void setRecipeTitle(String recipeTitle) {
+        this.recipeTitle = recipeTitle;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public void setImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+}

--- a/main-service/src/main/java/com/cookmate/main/repository/FavoriteRecipeRepository.java
+++ b/main-service/src/main/java/com/cookmate/main/repository/FavoriteRecipeRepository.java
@@ -1,0 +1,21 @@
+package com.cookmate.main.repository;
+
+import com.cookmate.main.model.FavoriteRecipe;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface FavoriteRecipeRepository extends JpaRepository<FavoriteRecipe, Long> {
+    
+    Page<FavoriteRecipe> findByUserId(String userId, Pageable pageable);
+    
+    boolean existsByUserIdAndRecipeId(String userId, String recipeId);
+    
+    Optional<FavoriteRecipe> findByUserIdAndRecipeId(String userId, String recipeId);
+    
+    void deleteByUserIdAndRecipeId(String userId, String recipeId);
+}

--- a/main-service/src/main/java/com/cookmate/main/service/FavoriteRecipeService.java
+++ b/main-service/src/main/java/com/cookmate/main/service/FavoriteRecipeService.java
@@ -1,0 +1,69 @@
+package com.cookmate.main.service;
+
+import com.cookmate.main.dto.FavoriteRecipeAddRequest;
+import com.cookmate.main.dto.FavoriteRecipeDTO;
+import com.cookmate.main.model.FavoriteRecipe;
+import com.cookmate.main.repository.FavoriteRecipeRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class FavoriteRecipeService {
+
+    private final FavoriteRecipeRepository favoriteRecipeRepository;
+
+    public FavoriteRecipeService(FavoriteRecipeRepository favoriteRecipeRepository) {
+        this.favoriteRecipeRepository = favoriteRecipeRepository;
+    }
+
+    public Page<FavoriteRecipeDTO> getUserFavorites(String userId, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<FavoriteRecipe> favorites = favoriteRecipeRepository.findByUserId(userId, pageable);
+        
+        return favorites.map(fav -> new FavoriteRecipeDTO(
+            fav.getId(),
+            fav.getRecipeId(),
+            fav.getRecipeTitle(),
+            fav.getImageUrl(),
+            fav.getCreatedAt()
+        ));
+    }
+
+    @Transactional
+    public FavoriteRecipeDTO addFavorite(String userId, String recipeId, FavoriteRecipeAddRequest request) {
+        if (favoriteRecipeRepository.existsByUserIdAndRecipeId(userId, recipeId)) {
+            // Alternatively, throw a custom exception
+            throw new IllegalArgumentException("Recipe is already in favorites");
+        }
+
+        FavoriteRecipe favorite = new FavoriteRecipe(
+            userId,
+            recipeId,
+            request.recipeTitle(),
+            request.imageUrl()
+        );
+
+        FavoriteRecipe saved = favoriteRecipeRepository.save(favorite);
+
+        return new FavoriteRecipeDTO(
+            saved.getId(),
+            saved.getRecipeId(),
+            saved.getRecipeTitle(),
+            saved.getImageUrl(),
+            saved.getCreatedAt()
+        );
+    }
+
+    public boolean isFavorite(String userId, String recipeId) {
+        return favoriteRecipeRepository.existsByUserIdAndRecipeId(userId, recipeId);
+    }
+
+    @Transactional
+    public void removeFavorite(String userId, String recipeId) {
+        favoriteRecipeRepository.deleteByUserIdAndRecipeId(userId, recipeId);
+    }
+}


### PR DESCRIPTION
# Feat: Dodanie funkcjonalności ulubionych przepisów (Favorites)
Closes #210 
## Opis zmian
Pull Request wprowadza pełną funkcjonalność dodawania, usuwania oraz przeglądania ulubionych przepisów. Zdecydowaliśmy się na implementację w ramach `main-service`, aby zachować spójność danych i zminimalizować koszty architektury (brak potrzeby stawiania nowego mikroserwisu). 

Aby znacząco odciążyć zewnętrzne API TheMealDB podczas listowania ulubionych przepisów, podstawowe meta-dane (tytuł i obrazek przepisu) są "cachowane" w naszej bazie w tabeli `user_favorite_recipes`.

## Backend (`main-service`)
- **[Model i Baza Danych](https://github.com/CookMate-Team/CookMate/blob/210-feat-dodanie-funkcjonalno%C5%9Bci-ulubionych-przepis%C3%B3w-favorites-w-main-service/main-service/src/main/java/com/cookmate/main/model/FavoriteRecipe.java):** Utworzono encję `FavoriteRecipe` z przypisanymi kolumnami dla `user_id`, `recipe_id`, `recipe_title` oraz `image_url`. Dodano unikalne ograniczenie `UniqueConstraint` dla pary `user_id` i `recipe_id`, zapobiegające duplikatom.
- **[Warstwa Danych](https://github.com/CookMate-Team/CookMate/blob/210-feat-dodanie-funkcjonalno%C5%9Bci-ulubionych-przepis%C3%B3w-favorites-w-main-service/main-service/src/main/java/com/cookmate/main/repository/FavoriteRecipeRepository.java):** Zaimplementowano `FavoriteRecipeRepository` dziedziczące po `JpaRepository`, obsługujące standardowy CRUD oraz wbudowaną paginację (`Pageable`).
- **[Logika Biznesowa](https://github.com/CookMate-Team/CookMate/blob/210-feat-dodanie-funkcjonalno%C5%9Bci-ulubionych-przepis%C3%B3w-favorites-w-main-service/main-service/src/main/java/com/cookmate/main/service/FavoriteRecipeService.java):** Stworzono `FavoriteRecipeService` implementujący metody do dodawania, usuwania, sprawdzania statusu (isFavorite) oraz pobierania ulubionych z uwzględnieniem stronicowania.
- **[Kontroler API](https://github.com/CookMate-Team/CookMate/blob/210-feat-dodanie-funkcjonalno%C5%9Bci-ulubionych-przepis%C3%B3w-favorites-w-main-service/main-service/src/main/java/com/cookmate/main/controller/FavoriteRecipeController.java):** Dodano `FavoriteRecipeController` wystawiający 4 endpointy chronione autoryzacją `@PreAuthorize("hasRole('ROLE_USER')")`. Token JWT jest dekodowany do zidentyfikowania odpowiedniego subiekta (`userId`).

## Frontend (`React` / `Zustand` / `React Query`)
- **[Globalny Stan (Zustand)](https://github.com/CookMate-Team/CookMate/blob/210-feat-dodanie-funkcjonalno%C5%9Bci-ulubionych-przepis%C3%B3w-favorites-w-main-service/frontend/src/store/useRecipeStore.ts):** Zaktualizowano `useRecipeStore.ts` by przechowywał nowy stan/źródło widoku (`FAVORITES`).
- **[Warstwa Komunikacji z API](https://github.com/CookMate-Team/CookMate/blob/210-feat-dodanie-funkcjonalno%C5%9Bci-ulubionych-przepis%C3%B3w-favorites-w-main-service/frontend/src/hooks/useFavorites.ts):** Utworzono plik `favoritesApi.ts` oraz odpowiednie hooki `useFavorites.ts` wykorzystujące bazowy `authFetch` do autoryzowanych zapytań za pomocą Keycloaka. Poprawiono błędy TS (`import type`).
- **[Przełączanie Widoków](https://github.com/CookMate-Team/CookMate/blob/210-feat-dodanie-funkcjonalno%C5%9Bci-ulubionych-przepis%C3%B3w-favorites-w-main-service/frontend/src/components/SourceToggle.tsx):** Zabezpieczono przyciski "Favorites" (w `Header.tsx` i `SourceToggle.tsx`). Wymuszają one zalogowanie w przypadku gdy użytkownik jest niezalogowany.
- **[Karty Przepisów](https://github.com/CookMate-Team/CookMate/blob/210-feat-dodanie-funkcjonalno%C5%9Bci-ulubionych-przepis%C3%B3w-favorites-w-main-service/frontend/src/components/RecipeCard.tsx):** Wzbogacono [RecipeCard.tsx](https://github.com/CookMate-Team/CookMate/blob/210-feat-dodanie-funkcjonalno%C5%9Bci-ulubionych-przepis%C3%B3w-favorites-w-main-service/frontend/src/components/RecipeCard.tsx) i [ExpandedRecipeCard.tsx](https://github.com/CookMate-Team/CookMate/blob/210-feat-dodanie-funkcjonalno%C5%9Bci-ulubionych-przepis%C3%B3w-favorites-w-main-service/frontend/src/components/ExpandedRecipeCard.tsx) o dynamiczną ikonę "serduszka".
- **[Zamykanie Modala (UX/UI)](https://github.com/CookMate-Team/CookMate/blob/210-feat-dodanie-funkcjonalno%C5%9Bci-ulubionych-przepis%C3%B3w-favorites-w-main-service/frontend/src/App.tsx):** W [App.tsx](https://github.com/CookMate-Team/CookMate/blob/210-feat-dodanie-funkcjonalno%C5%9Bci-ulubionych-przepis%C3%B3w-favorites-w-main-service/frontend/src/App.tsx) rozszerzono funkcjonalność okna logowania – modal zamyka się teraz komfortowo po kliknięciu poza jego granice w szare tło (stop propagation).
- **[Paginacja i Lista](https://github.com/CookMate-Team/CookMate/blob/210-feat-dodanie-funkcjonalno%C5%9Bci-ulubionych-przepis%C3%B3w-favorites-w-main-service/frontend/src/components/RecipeGallery.tsx):** Wdrożono przycisk *"Load More"* w widoku galerii, obsługiwany asynchronicznie przez wydajny system z `useInfiniteQuery`.

## Checklist
- [x] Backend buforuje podstawowe metadane (ograniczenie liczby wywołań do TheMealDB).
- [x] Uniemożliwiono duplikowanie w bazie danych (`UniqueConstraint`).
- [x] Niezalogowani użytkownicy są witani oknem modalu po kliknięciu w "Serduszko" lub sekcję Ulubionych.
- [x] Modale zamykane są w intuicyjny sposób (przez kliknięcie tła).
- [x] Aplikacja poprawnie kompiluje się z flagą `verbatimModuleSyntax`.
- [x] Rozwiązanie przetestowane lokalnie – w pełni gotowe do wdrożenia.