### PR TITLE
218 feature zapisywanie planów posiłków i powiązanie z użytkownikiem

### DIFF
--- a/config-repo/gateway-service.yml
+++ b/config-repo/gateway-service.yml
@@ -57,13 +57,20 @@ spring:
               filters:
                 - TokenRelay
               order: 2
+            - id: meal-planner-service
+              uri: lb://meal-planner-service
+              predicates:
+                - Path=/api/planner/**
+              filters:
+                - TokenRelay
+              order: 3
             - id: main-service
               uri: lb://main-service
               predicates:
                 - Path=/api/**
               filters:
                 - TokenRelay
-              order: 3
+              order: 4
 
 management:
   endpoints:

--- a/config-repo/meal-planner-service.yml
+++ b/config-repo/meal-planner-service.yml
@@ -2,6 +2,26 @@
 server:
   port: 8086
 
+spring:
+  datasource:
+    url: jdbc:postgresql://${DB_HOST:localhost}:5432/${DB_NAME:cookmate}
+    username: ${DB_USER:cookmate}
+    password: ${DB_PASS:cookmate}
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        format_sql: true
+        default_schema: meal_planner
+  sql:
+    init:
+      mode: always
+      schema-locations: classpath:schema.sql
+
 meal-planner-service:
   main-service-url: http://main-service:8081
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -311,7 +311,13 @@ services:
     environment:
       CONFIG_SERVER_URL: http://config-service:8888
       EUREKA_SERVER_URL: http://discovery-service:8761/eureka/
+      DB_HOST: ${DB_HOST}
+      DB_NAME: ${DB_NAME}
+      DB_USER: ${DB_USER}
+      DB_PASS: ${DB_PASS}
     depends_on:
+      postgres:
+        condition: service_healthy
       discovery-service:
         condition: service_healthy
       main-service:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -107,7 +107,7 @@ function AppContent() {
   if (showMealPlanner) {
     return (
       <div className="min-h-screen flex flex-col">
-        <Header onHomeClick={handleCloseMealPlanner} onMealPlannerClick={handleOpenMealPlanner} />
+        <Header onHomeClick={handleCloseMealPlanner} onMealPlannerClick={handleOpenMealPlanner} isMealPlannerActive={true} />
         <main className="flex-grow">
           <MealPlannerPanel
             onRequireLogin={() => setShowLoginModal(true)}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { Header } from './components/Header';
 import { Footer } from './components/Footer';
 import { RecipeGallery } from './components/RecipeGallery';
 import { GuidedCookingLayout } from './components/GuidedCookingLayout';
+import { MealPlannerPanel } from './components/MealPlannerPanel';
 import { GuidedCookingProvider } from './context/GuidedCookingProvider';
 import { AuthProvider, useAuth } from './context/AuthContext';
 import { useRecipeStore } from './store/useRecipeStore';
@@ -29,6 +30,7 @@ function AuthLoader({ children }: { children: React.ReactNode }) {
 function AppContent() {
   const { isAuthenticated, login, register } = useAuth();
   const [cookingRecipeId, setCookingRecipeId] = useState<string | null>(null);
+  const [showMealPlanner, setShowMealPlanner] = useState(false);
   const [showLoginModal, setShowLoginModal] = useState(false);
   const source = useRecipeStore((state) => state.source);
 
@@ -45,9 +47,23 @@ function AppContent() {
     setCookingRecipeId(null);
   };
 
-  // Close guided cooking view if user switches source (tab) in the navbar
+  const handleOpenMealPlanner = () => {
+    if (!isAuthenticated) {
+      setShowLoginModal(true);
+      return;
+    }
+    setCookingRecipeId(null);
+    setShowMealPlanner(true);
+  };
+
+  const handleCloseMealPlanner = () => {
+    setShowMealPlanner(false);
+  };
+
+  // Close guided cooking / meal planner if user switches source (tab) in the navbar
   useEffect(() => {
     setCookingRecipeId(null);
+    setShowMealPlanner(false);
   }, [source]);
 
   // Restore pending cooking session after successful login
@@ -65,7 +81,7 @@ function AppContent() {
   if (cookingRecipeId) {
     return (
       <div className="h-screen flex flex-col overflow-hidden">
-        <Header onHomeClick={handleCloseCooking} />
+        <Header onHomeClick={handleCloseCooking} onMealPlannerClick={handleOpenMealPlanner} />
         <GuidedCookingLayout
           recipeId={cookingRecipeId}
           onClose={handleCloseCooking}
@@ -74,10 +90,60 @@ function AppContent() {
     );
   }
 
+  // ── Meal Planner Mode ──
+  if (showMealPlanner) {
+    return (
+      <div className="min-h-screen flex flex-col">
+        <Header onHomeClick={handleCloseMealPlanner} onMealPlannerClick={handleOpenMealPlanner} />
+        <main className="flex-grow">
+          <MealPlannerPanel onRequireLogin={() => setShowLoginModal(true)} />
+        </main>
+        <Footer />
+
+        {showLoginModal && (
+          <div
+            className="fixed inset-0 z-[100] flex items-center justify-center bg-stone-900/50 backdrop-blur-sm p-4"
+            onClick={() => setShowLoginModal(false)}
+          >
+            <div
+              className="bg-white rounded-2xl p-8 max-w-md w-full shadow-2xl relative"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <button
+                onClick={() => setShowLoginModal(false)}
+                className="absolute top-4 right-4 text-stone-400 hover:text-stone-600 transition"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+              <div className="text-center mb-6">
+                <div className="text-5xl mb-4">🍳</div>
+                <h2 className="text-2xl font-bold text-stone-800 mb-2">Login Required</h2>
+                <p className="text-stone-600">To use this feature and save your progress, you need to log in.</p>
+              </div>
+              <div className="flex flex-col gap-3">
+                <button onClick={login} className="w-full bg-gradient-to-r from-amber-500 to-orange-500 text-white font-bold py-3 px-4 rounded-xl shadow-md hover:shadow-lg hover:scale-[1.02] transition-all duration-200">
+                  Log In
+                </button>
+                <button onClick={register} className="w-full bg-stone-100 text-amber-600 font-bold py-3 px-4 rounded-xl shadow-md hover:shadow-lg hover:bg-stone-200 transition-all duration-200">
+                  Create Account
+                </button>
+                <button onClick={() => setShowLoginModal(false)} className="w-full bg-transparent border border-stone-200 text-stone-600 font-medium py-3 px-4 rounded-xl hover:bg-stone-50 transition-colors">
+                  Cancel
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  }
+
   // ── Default Gallery Mode ──
   return (
     <div className="min-h-screen flex flex-col">
-      <Header onHomeClick={handleCloseCooking} />
+      <Header onHomeClick={handleCloseCooking} onMealPlannerClick={handleOpenMealPlanner} />
       <main className="flex-grow max-w-7xl mx-auto w-full px-4 sm:px-6 lg:px-8 py-8">
         <div className="text-center mb-8">
           <h1 className="text-4xl font-extrabold text-stone-800 tracking-tight">What are you craving?</h1>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -96,7 +96,10 @@ function AppContent() {
       <div className="min-h-screen flex flex-col">
         <Header onHomeClick={handleCloseMealPlanner} onMealPlannerClick={handleOpenMealPlanner} />
         <main className="flex-grow">
-          <MealPlannerPanel onRequireLogin={() => setShowLoginModal(true)} />
+          <MealPlannerPanel
+            onRequireLogin={() => setShowLoginModal(true)}
+            onStartCooking={handleStartCooking}
+          />
         </main>
         <Footer />
 

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -5,9 +5,10 @@ import { useAuth } from '../context/AuthContext';
 interface HeaderProps {
   onHomeClick?: () => void;
   onMealPlannerClick?: () => void;
+  isMealPlannerActive?: boolean;
 }
 
-export function Header({ onHomeClick, onMealPlannerClick }: HeaderProps) {
+export function Header({ onHomeClick, onMealPlannerClick, isMealPlannerActive }: HeaderProps) {
   const { isAuthenticated, user, login, logout, register } = useAuth();
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -38,7 +39,10 @@ export function Header({ onHomeClick, onMealPlannerClick }: HeaderProps) {
         </div>
 
         <div className="flex items-center gap-4">
-          <SourceToggle />
+          <SourceToggle 
+            onMealPlannerClick={onMealPlannerClick} 
+            isMealPlannerActive={isMealPlannerActive} 
+          />
 
           {isAuthenticated && user ? (
             // ── Zalogowany — avatar z dropdownem ──

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -5,9 +5,10 @@ import { useRecipeStore } from '../store/useRecipeStore';
 
 interface HeaderProps {
   onHomeClick?: () => void;
+  onMealPlannerClick?: () => void;
 }
 
-export function Header({ onHomeClick }: HeaderProps) {
+export function Header({ onHomeClick, onMealPlannerClick }: HeaderProps) {
   const { isAuthenticated, user, login, logout, register } = useAuth();
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -59,6 +60,21 @@ export function Header({ onHomeClick }: HeaderProps) {
             title={!isAuthenticated ? "Log in to access" : undefined}
           >
             Favorites
+          </a>
+          <a
+            href="#"
+            onClick={(e) => {
+              e.preventDefault();
+              if (!isAuthenticated) {
+                login();
+              } else {
+                onMealPlannerClick?.();
+              }
+            }}
+            className={isAuthenticated ? "text-white hover:text-amber-100 font-medium transition-colors" : "text-white/50 cursor-not-allowed font-medium transition-colors"}
+            title={!isAuthenticated ? "Log in to access" : undefined}
+          >
+            Meal Planner
           </a>
           <a
             href="#"

--- a/frontend/src/components/MealPlannerPanel.tsx
+++ b/frontend/src/components/MealPlannerPanel.tsx
@@ -9,14 +9,38 @@ import {
 } from '../hooks/useMealPlanner';
 import type { WeeklyPlanResponse, ShoppingListResponse } from '../types/mealPlanner';
 
+const API_ERROR_MESSAGES: Record<string, string> = {
+  MAIN_SERVICE_UNAVAILABLE: 'The recipe service is currently unavailable. Please try again in a moment.',
+  MEAL_PLAN_GENERATION_FAILED: 'Could not generate the meal plan. Please try again.',
+  WEEKLY_PLAN_NOT_FOUND: 'This plan could not be found. It may have already been deleted.',
+  VALIDATION_ERROR: 'Invalid request — please check your settings and try again.',
+};
+
 function parseApiError(raw: string): string {
+  if (!raw) return 'Something went wrong. Please try again.';
+
+  // Network-level errors thrown by the browser / fetch API
+  if (
+    raw === 'Failed to fetch' ||
+    raw.toLowerCase().includes('networkerror') ||
+    raw.toLowerCase().includes('load failed')
+  ) {
+    return 'Could not reach the server. Please check your internet connection.';
+  }
+
   try {
     const parsed = JSON.parse(raw);
-    if (parsed.message) return parsed.message;
+    if (parsed.code && API_ERROR_MESSAGES[parsed.code]) {
+      return API_ERROR_MESSAGES[parsed.code];
+    }
+    if (typeof parsed.message === 'string' && parsed.message) {
+      return parsed.message;
+    }
   } catch {
-    // not JSON – use as-is
+    // not JSON
   }
-  return raw;
+
+  return 'Something went wrong. Please try again.';
 }
 
 function downloadAsTxt(list: ShoppingListResponse, planLabel: string) {
@@ -57,15 +81,12 @@ function Spinner() {
 
 function ErrorBanner({ message, onDismiss }: { message: string; onDismiss: () => void }) {
   return (
-    <div className="bg-red-50 border border-red-200 rounded-xl px-4 py-3 text-red-600 text-sm flex items-start gap-2">
-      <span className="text-lg leading-none flex-shrink-0">⚠️</span>
-      <div className="flex-1">
-        <p className="font-semibold">An error occurred</p>
-        <p className="mt-0.5">{message}</p>
-      </div>
+    <div className="bg-red-50 border border-red-200 rounded-xl px-4 py-3 text-red-700 text-sm flex items-center gap-3">
+      <span className="text-base leading-none flex-shrink-0">⚠️</span>
+      <p className="flex-1">{message}</p>
       <button
         onClick={onDismiss}
-        className="text-red-400 hover:text-red-600 transition-colors flex-shrink-0 p-1"
+        className="text-red-400 hover:text-red-600 transition-colors flex-shrink-0 p-1 rounded"
         aria-label="Close"
       >
         ✕

--- a/frontend/src/components/MealPlannerPanel.tsx
+++ b/frontend/src/components/MealPlannerPanel.tsx
@@ -1,0 +1,365 @@
+import { useState } from 'react';
+import { useAuth } from '../context/AuthContext';
+import {
+  useGenerateWeeklyPlan,
+  useSaveWeeklyPlan,
+  useWeeklyPlanHistory,
+  useDeleteWeeklyPlan,
+  useGenerateShoppingListFromPlan,
+} from '../hooks/useMealPlanner';
+import type { WeeklyPlanResponse, ShoppingListResponse } from '../types/mealPlanner';
+
+function parseApiError(raw: string): string {
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed.message) return parsed.message;
+  } catch {
+    // not JSON – use as-is
+  }
+  return raw;
+}
+
+function downloadAsTxt(list: ShoppingListResponse, planLabel: string) {
+  const date = new Date().toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' });
+  const lines = [
+    `Shopping List — ${planLabel}`,
+    `Generated: ${date}`,
+    '',
+    ...list.items.map((item) => {
+      const measures = item.measures.filter(Boolean).join(', ');
+      return measures ? `• ${item.name}: ${measures}` : `• ${item.name}`;
+    }),
+  ];
+  const blob = new Blob([lines.join('\n')], { type: 'text/plain;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `shopping-list-${Date.now()}.txt`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+interface MealPlannerPanelProps {
+  onRequireLogin: () => void;
+}
+
+function Spinner() {
+  return (
+    <svg className="animate-spin h-5 w-5" viewBox="0 0 24 24" fill="none">
+      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+    </svg>
+  );
+}
+
+function ErrorBanner({ message, onDismiss }: { message: string; onDismiss: () => void }) {
+  return (
+    <div className="bg-red-50 border border-red-200 rounded-xl px-4 py-3 text-red-600 text-sm flex items-start gap-2">
+      <span className="text-lg leading-none flex-shrink-0">⚠️</span>
+      <div className="flex-1">
+        <p className="font-semibold">An error occurred</p>
+        <p className="mt-0.5">{message}</p>
+      </div>
+      <button
+        onClick={onDismiss}
+        className="text-red-400 hover:text-red-600 transition-colors flex-shrink-0 p-1"
+        aria-label="Close"
+      >
+        ✕
+      </button>
+    </div>
+  );
+}
+
+export function MealPlannerPanel({ onRequireLogin }: MealPlannerPanelProps) {
+  const { isAuthenticated } = useAuth();
+  const [mealsPerDay, setMealsPerDay] = useState(3);
+  const [generatedPlan, setGeneratedPlan] = useState<WeeklyPlanResponse | null>(null);
+  const [planError, setPlanError] = useState<string | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  // accordion: id of the currently expanded saved plan card
+  const [expandedPlanId, setExpandedPlanId] = useState<string | null>(null);
+  // id of the plan whose shopping list is currently being downloaded (for loading state)
+  const [downloadingPlanId, setDownloadingPlanId] = useState<string | null>(null);
+  const [downloadError, setDownloadError] = useState<string | null>(null);
+
+  const generatePlan = useGenerateWeeklyPlan();
+  const savePlan = useSaveWeeklyPlan();
+  const deletePlan = useDeleteWeeklyPlan();
+  const generateShoppingFromPlan = useGenerateShoppingListFromPlan();
+  const { data: planHistory } = useWeeklyPlanHistory();
+
+  const handleGeneratePlan = async () => {
+    if (!isAuthenticated) { onRequireLogin(); return; }
+    setPlanError(null);
+    setGeneratedPlan(null);
+    try {
+      const plan = await generatePlan.mutateAsync(mealsPerDay);
+      setGeneratedPlan(plan);
+    } catch (err: any) {
+      setPlanError(parseApiError(err.message ?? 'Failed to generate plan'));
+    }
+  };
+
+  // Save plan → hide Section 2; plan appears in Saved Plans list via query invalidation
+  const handleSavePlan = async () => {
+    if (!generatedPlan) return;
+    setSaveError(null);
+    try {
+      await savePlan.mutateAsync(generatedPlan);
+      setGeneratedPlan(null);
+    } catch (err: any) {
+      setSaveError(parseApiError(err.message ?? 'Failed to save plan'));
+    }
+  };
+
+  const handleDeletePlan = async (planId: string) => {
+    try {
+      await deletePlan.mutateAsync(planId);
+      if (expandedPlanId === planId) setExpandedPlanId(null);
+    } catch {
+      // plan already gone; history refreshes automatically
+    }
+  };
+
+  const handleDownloadShoppingList = async (planId: string, dateLabel: string) => {
+    if (!isAuthenticated) { onRequireLogin(); return; }
+    setDownloadingPlanId(planId);
+    setDownloadError(null);
+    try {
+      const list = await generateShoppingFromPlan.mutateAsync(planId);
+      downloadAsTxt(list, `plan from ${dateLabel}`);
+    } catch (err: any) {
+      setDownloadError(parseApiError(err.message ?? 'Failed to generate shopping list'));
+    } finally {
+      setDownloadingPlanId(null);
+    }
+  };
+
+  const toggleExpanded = (planId: string) => {
+    setExpandedPlanId((prev) => (prev === planId ? null : planId));
+    setDownloadError(null);
+  };
+
+  return (
+    <div className="max-w-5xl mx-auto w-full px-4 sm:px-6 lg:px-8 py-8 space-y-8">
+
+      {/* ── Header ── */}
+      <div className="text-center">
+        <h1 className="text-4xl font-extrabold text-stone-800 tracking-tight">Weekly Meal Planner</h1>
+        <p className="mt-3 text-lg text-stone-500 max-w-xl mx-auto">
+          Generate a personalised 7-day meal plan and download your shopping list in one click.
+        </p>
+      </div>
+
+      {/* ── Section 1: Generate Plan ── */}
+      <div className="bg-white rounded-2xl shadow-md border border-stone-100 p-6 space-y-5">
+        <h2 className="text-xl font-bold text-stone-800">Generate a Plan</h2>
+        <div className="flex flex-wrap items-end gap-4">
+          <div className="flex flex-col gap-1">
+            <label className="text-sm font-semibold text-stone-600">Meals per day</label>
+            <div className="flex items-center gap-2">
+              {[1, 2, 3, 4, 5].map((n) => (
+                <button
+                  key={n}
+                  onClick={() => setMealsPerDay(n)}
+                  className={`w-10 h-10 rounded-xl font-bold transition-all duration-150 ${
+                    mealsPerDay === n
+                      ? 'bg-gradient-to-br from-amber-500 to-orange-500 text-white shadow-md scale-105'
+                      : 'bg-stone-100 text-stone-600 hover:bg-amber-100 hover:text-amber-700'
+                  }`}
+                >
+                  {n}
+                </button>
+              ))}
+            </div>
+          </div>
+          <button
+            onClick={handleGeneratePlan}
+            disabled={generatePlan.isPending}
+            className="flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-amber-500 to-orange-500 text-white font-bold rounded-xl shadow-md hover:shadow-lg hover:scale-[1.02] active:scale-[0.98] transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100"
+          >
+            {generatePlan.isPending ? <><Spinner /> Generating...</> : 'Generate Plan'}
+          </button>
+        </div>
+        {planError && <ErrorBanner message={planError} onDismiss={() => setPlanError(null)} />}
+      </div>
+
+      {/* ── Section 2: Freshly Generated Plan (temporary — hidden after saving) ── */}
+      {generatedPlan && (
+        <div className="bg-white rounded-2xl shadow-md border border-stone-100 p-6 space-y-5">
+          <div className="flex items-center justify-between flex-wrap gap-3">
+            <h2 className="text-xl font-bold text-stone-800">Your 7-Day Plan</h2>
+            <button
+              onClick={handleSavePlan}
+              disabled={savePlan.isPending}
+              className="flex items-center gap-2 px-5 py-2.5 bg-gradient-to-r from-amber-500 to-orange-500 text-white font-bold rounded-xl shadow hover:shadow-md hover:scale-[1.02] active:scale-[0.98] transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100"
+            >
+              {savePlan.isPending ? <><Spinner /> Saving...</> : 'Save Plan'}
+            </button>
+          </div>
+
+          {saveError && <ErrorBanner message={saveError} onDismiss={() => setSaveError(null)} />}
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+            {generatedPlan.days.map((dayPlan) => (
+              <div key={dayPlan.day} className="bg-stone-50 rounded-xl border border-stone-200 p-4 space-y-3">
+                <h3 className="font-bold text-stone-700 text-sm uppercase tracking-wider">{dayPlan.day}</h3>
+                <div className="space-y-2">
+                  {dayPlan.meals.map((meal) => (
+                    <div key={meal.id} className="flex items-center gap-2">
+                      <img
+                        src={meal.thumbnailUrl}
+                        alt={meal.name}
+                        className="w-10 h-10 rounded-lg object-cover flex-shrink-0 shadow-sm"
+                        onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
+                      />
+                      <span className="text-sm text-stone-700 font-medium leading-tight">{meal.name}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* ── Section 3: Saved Plans (accordion) ── */}
+      {isAuthenticated && (
+        <div className="bg-white rounded-2xl shadow-md border border-stone-100 p-6 space-y-4">
+          <h2 className="text-xl font-bold text-stone-800">
+            Saved Plans
+            <span className="ml-2 text-sm font-medium text-stone-400 bg-stone-100 px-2 py-0.5 rounded-full">
+              {planHistory?.length ?? 0}
+            </span>
+          </h2>
+
+          {!planHistory || planHistory.length === 0 ? (
+            <p className="text-sm text-stone-400 italic text-center py-4">
+              No saved plans yet. Generate and save a plan to see it here.
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {planHistory.map((saved) => {
+                const allMeals = saved.days.flatMap((d) => d.meals);
+                const isExpanded = expandedPlanId === saved.id;
+                const isDownloading = downloadingPlanId === saved.id;
+                const dateLabel = new Date(saved.createdAt).toLocaleDateString(undefined, {
+                  day: 'numeric', month: 'short', year: 'numeric',
+                });
+
+                return (
+                  <div
+                    key={saved.id}
+                    className={`rounded-xl border transition-colors duration-150 ${
+                      isExpanded ? 'border-amber-200 bg-amber-50/40' : 'border-stone-200 bg-stone-50'
+                    }`}
+                  >
+                    {/* ── Collapsed header (always visible) ── */}
+                    <div className="flex items-center gap-3 p-4">
+                      {/* meal thumbnail strip */}
+                      <div className="flex gap-1 flex-shrink-0">
+                        {allMeals.slice(0, 5).map((meal) => (
+                          <img
+                            key={meal.id}
+                            src={meal.thumbnailUrl}
+                            alt={meal.name}
+                            title={meal.name}
+                            className="w-8 h-8 rounded-lg object-cover shadow-sm"
+                            onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
+                          />
+                        ))}
+                        {allMeals.length > 5 && (
+                          <span className="w-8 h-8 rounded-lg bg-stone-200 text-stone-500 text-xs flex items-center justify-center font-semibold flex-shrink-0">
+                            +{allMeals.length - 5}
+                          </span>
+                        )}
+                      </div>
+
+                      {/* text info — clickable to expand */}
+                      <button
+                        onClick={() => toggleExpanded(saved.id)}
+                        className="flex-1 text-left min-w-0"
+                      >
+                        <p className="font-semibold text-stone-700 text-sm truncate">
+                          {saved.mealsPerDay} meal{saved.mealsPerDay !== 1 ? 's' : ''} / day
+                          <span className="ml-2 text-xs font-normal text-stone-400">({allMeals.length} total)</span>
+                        </p>
+                        <p className="text-xs text-stone-400 mt-0.5">{dateLabel}</p>
+                      </button>
+
+                      {/* expand chevron */}
+                      <button
+                        onClick={() => toggleExpanded(saved.id)}
+                        className="text-stone-400 hover:text-stone-600 transition-colors flex-shrink-0 p-1"
+                        aria-label={isExpanded ? 'Collapse' : 'Expand'}
+                      >
+                        <svg
+                          className={`w-5 h-5 transition-transform duration-200 ${isExpanded ? 'rotate-180' : ''}`}
+                          fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}
+                        >
+                          <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+                        </svg>
+                      </button>
+                    </div>
+
+                    {/* ── Expanded content ── */}
+                    {isExpanded && (
+                      <div className="px-4 pb-4 space-y-4 border-t border-amber-200/60">
+                        {/* day grid */}
+                        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3 pt-4">
+                          {saved.days.map((dayPlan) => (
+                            <div key={dayPlan.day} className="bg-white rounded-xl border border-stone-200 p-3 space-y-2">
+                              <h3 className="font-bold text-stone-700 text-xs uppercase tracking-wider">{dayPlan.day}</h3>
+                              <div className="space-y-1.5">
+                                {dayPlan.meals.map((meal) => (
+                                  <div key={meal.id} className="flex items-center gap-2">
+                                    <img
+                                      src={meal.thumbnailUrl}
+                                      alt={meal.name}
+                                      className="w-9 h-9 rounded-lg object-cover flex-shrink-0 shadow-sm"
+                                      onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
+                                    />
+                                    <span className="text-xs text-stone-700 font-medium leading-tight">{meal.name}</span>
+                                  </div>
+                                ))}
+                              </div>
+                            </div>
+                          ))}
+                        </div>
+
+                        {/* actions row */}
+                        <div className="flex items-center gap-3 flex-wrap pt-1">
+                          <button
+                            onClick={() => handleDownloadShoppingList(saved.id, dateLabel)}
+                            disabled={isDownloading}
+                            className="flex items-center gap-2 text-sm font-bold px-4 py-2 bg-gradient-to-r from-orange-500 to-red-500 text-white rounded-xl shadow hover:shadow-md hover:scale-[1.02] active:scale-[0.98] transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100"
+                          >
+                            {isDownloading ? <><Spinner /> Generating...</> : 'Download Shopping List'}
+                          </button>
+                          <button
+                            onClick={() => handleDeletePlan(saved.id)}
+                            disabled={deletePlan.isPending}
+                            className="text-sm text-stone-400 hover:text-red-500 hover:bg-red-50 border border-transparent hover:border-red-200 px-3 py-2 rounded-xl transition-all duration-150 disabled:opacity-40"
+                          >
+                            Delete
+                          </button>
+                        </div>
+
+                        {downloadError && downloadingPlanId === null && expandedPlanId === saved.id && (
+                          <ErrorBanner message={downloadError} onDismiss={() => setDownloadError(null)} />
+                        )}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/MealPlannerPanel.tsx
+++ b/frontend/src/components/MealPlannerPanel.tsx
@@ -43,6 +43,7 @@ function downloadAsTxt(list: ShoppingListResponse, planLabel: string) {
 
 interface MealPlannerPanelProps {
   onRequireLogin: () => void;
+  onStartCooking: (recipeId: string) => void;
 }
 
 function Spinner() {
@@ -73,7 +74,7 @@ function ErrorBanner({ message, onDismiss }: { message: string; onDismiss: () =>
   );
 }
 
-export function MealPlannerPanel({ onRequireLogin }: MealPlannerPanelProps) {
+export function MealPlannerPanel({ onRequireLogin, onStartCooking }: MealPlannerPanelProps) {
   const { isAuthenticated } = useAuth();
   const [mealsPerDay, setMealsPerDay] = useState(3);
   const [generatedPlan, setGeneratedPlan] = useState<WeeklyPlanResponse | null>(null);
@@ -315,14 +316,21 @@ export function MealPlannerPanel({ onRequireLogin }: MealPlannerPanelProps) {
                               <h3 className="font-bold text-stone-700 text-xs uppercase tracking-wider">{dayPlan.day}</h3>
                               <div className="space-y-1.5">
                                 {dayPlan.meals.map((meal) => (
-                                  <div key={meal.id} className="flex items-center gap-2">
+                                  <div key={meal.id} className="flex items-center gap-2 group">
                                     <img
                                       src={meal.thumbnailUrl}
                                       alt={meal.name}
                                       className="w-9 h-9 rounded-lg object-cover flex-shrink-0 shadow-sm"
                                       onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
                                     />
-                                    <span className="text-xs text-stone-700 font-medium leading-tight">{meal.name}</span>
+                                    <span className="text-xs text-stone-700 font-medium leading-tight flex-1 min-w-0">{meal.name}</span>
+                                    <button
+                                      onClick={() => onStartCooking(meal.id)}
+                                      title="Start cooking"
+                                      className="flex-shrink-0 opacity-0 group-hover:opacity-100 text-xs font-semibold text-amber-600 hover:text-white hover:bg-gradient-to-r hover:from-amber-500 hover:to-orange-500 border border-amber-300 hover:border-transparent px-2 py-0.5 rounded-lg transition-all duration-150"
+                                    >
+                                      ▶ Cook
+                                    </button>
                                   </div>
                                 ))}
                               </div>

--- a/frontend/src/components/SourceToggle.tsx
+++ b/frontend/src/components/SourceToggle.tsx
@@ -3,7 +3,15 @@ import { useRecipeStore } from '../store/useRecipeStore';
 import { useGlobalActiveSession } from '../hooks/useGlobalActiveSession';
 import { useAuth } from '../context/AuthContext';
 
-export function SourceToggle({ className = '' }: { className?: string }) {
+export function SourceToggle({ 
+  className = '',
+  onMealPlannerClick,
+  isMealPlannerActive
+}: { 
+  className?: string;
+  onMealPlannerClick?: () => void;
+  isMealPlannerActive?: boolean;
+}) {
   const { source, setSource } = useRecipeStore();
   const { data: activeSession } = useGlobalActiveSession();
   const { isAuthenticated, login } = useAuth();
@@ -17,9 +25,23 @@ export function SourceToggle({ className = '' }: { className?: string }) {
   return (
     <div className={`flex items-center ${className}`}>
       <div className="bg-white/20 p-1 rounded-full shadow-sm inline-flex backdrop-blur-sm border border-white/30">
+        {onMealPlannerClick && (
+          <button 
+            onClick={onMealPlannerClick}
+            className={`px-4 py-1.5 rounded-full text-sm font-semibold transition-all duration-300 ${isMealPlannerActive ? 'bg-white text-orange-600 shadow-sm' : 'text-white/80 hover:text-white hover:bg-white/10'}`}
+          >
+            Meal Planner
+          </button>
+        )}
         <button 
-          onClick={() => setSource('LOCAL')}
-          className={`px-4 py-1.5 rounded-full text-sm font-semibold transition-all duration-300 ${source === 'LOCAL' ? 'bg-white text-orange-600 shadow-sm' : 'text-white/80 hover:text-white hover:bg-white/10'}`}
+          onClick={() => {
+            if (onMealPlannerClick) {
+              // If meal planner is active and user clicks a source, we might need to close it, 
+              // but App.tsx handles closing meal planner on source change via useEffect
+            }
+            setSource('LOCAL');
+          }}
+          className={`px-4 py-1.5 rounded-full text-sm font-semibold transition-all duration-300 ${source === 'LOCAL' && !isMealPlannerActive ? 'bg-white text-orange-600 shadow-sm' : 'text-white/80 hover:text-white hover:bg-white/10'}`}
         >
           My Recipes
         </button>
@@ -31,20 +53,20 @@ export function SourceToggle({ className = '' }: { className?: string }) {
               setSource('FAVORITES');
             }
           }}
-          className={`px-4 py-1.5 rounded-full text-sm font-semibold transition-all duration-300 ${source === 'FAVORITES' ? 'bg-white text-orange-600 shadow-sm' : 'text-white/80 hover:text-white hover:bg-white/10'}`}
+          className={`px-4 py-1.5 rounded-full text-sm font-semibold transition-all duration-300 ${source === 'FAVORITES' && !isMealPlannerActive ? 'bg-white text-orange-600 shadow-sm' : 'text-white/80 hover:text-white hover:bg-white/10'}`}
         >
           Favorites
         </button>
         <button 
           onClick={() => setSource('DISCOVERY')}
-          className={`px-4 py-1.5 rounded-full text-sm font-semibold transition-all duration-300 ${source === 'DISCOVERY' ? 'bg-white text-orange-600 shadow-sm' : 'text-white/80 hover:text-white hover:bg-white/10'}`}
+          className={`px-4 py-1.5 rounded-full text-sm font-semibold transition-all duration-300 ${source === 'DISCOVERY' && !isMealPlannerActive ? 'bg-white text-orange-600 shadow-sm' : 'text-white/80 hover:text-white hover:bg-white/10'}`}
         >
           Discover
         </button>
         {activeSession && (
           <button 
             onClick={() => setSource('ACTIVE')}
-            className={`px-4 py-1.5 rounded-full text-sm font-semibold transition-all duration-300 flex items-center gap-1.5 ${source === 'ACTIVE' ? 'bg-white text-orange-600 shadow-sm' : 'text-white/80 hover:text-white hover:bg-white/10'}`}
+            className={`px-4 py-1.5 rounded-full text-sm font-semibold transition-all duration-300 flex items-center gap-1.5 ${source === 'ACTIVE' && !isMealPlannerActive ? 'bg-white text-orange-600 shadow-sm' : 'text-white/80 hover:text-white hover:bg-white/10'}`}
           >
             <span className="w-2 h-2 bg-red-500 rounded-full animate-pulse" />
             Cooking Now

--- a/frontend/src/hooks/useMealPlanner.ts
+++ b/frontend/src/hooks/useMealPlanner.ts
@@ -1,0 +1,78 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  generateWeeklyPlan,
+  saveWeeklyPlan,
+  getWeeklyPlanHistory,
+  deleteWeeklyPlan,
+  generateShoppingList,
+  saveShoppingList,
+  getShoppingListHistory,
+  generateShoppingListFromPlan,
+} from '../services/mealPlannerApi';
+import { useAuth } from '../context/AuthContext';
+
+export const useWeeklyPlanHistory = () => {
+  const { isAuthenticated } = useAuth();
+  return useQuery({
+    queryKey: ['weekly-plan-history'],
+    queryFn: getWeeklyPlanHistory,
+    enabled: isAuthenticated,
+  });
+};
+
+export const useGenerateWeeklyPlan = () => {
+  return useMutation({
+    mutationFn: (mealsPerDay: number) => generateWeeklyPlan(mealsPerDay),
+  });
+};
+
+export const useSaveWeeklyPlan = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: saveWeeklyPlan,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['weekly-plan-history'] });
+    },
+  });
+};
+
+export const useDeleteWeeklyPlan = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (weeklyPlanId: string) => deleteWeeklyPlan(weeklyPlanId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['weekly-plan-history'] });
+    },
+  });
+};
+
+export const useShoppingListHistory = () => {
+  const { isAuthenticated } = useAuth();
+  return useQuery({
+    queryKey: ['shopping-list-history'],
+    queryFn: getShoppingListHistory,
+    enabled: isAuthenticated,
+  });
+};
+
+export const useGenerateShoppingList = () => {
+  return useMutation({
+    mutationFn: (mealIds: string[]) => generateShoppingList(mealIds),
+  });
+};
+
+export const useGenerateShoppingListFromPlan = () => {
+  return useMutation({
+    mutationFn: (weeklyPlanId: string) => generateShoppingListFromPlan(weeklyPlanId),
+  });
+};
+
+export const useSaveShoppingList = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: saveShoppingList,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['shopping-list-history'] });
+    },
+  });
+};

--- a/frontend/src/services/mealPlannerApi.ts
+++ b/frontend/src/services/mealPlannerApi.ts
@@ -1,0 +1,96 @@
+import { authFetch } from './authFetch';
+import type {
+  WeeklyPlanResponse,
+  SavedWeeklyPlanResponse,
+  ShoppingListResponse,
+  SavedShoppingListResponse,
+} from '../types/mealPlanner';
+
+const API_BASE_URL = '/api/planner';
+
+export const generateWeeklyPlan = async (mealsPerDay: number): Promise<WeeklyPlanResponse> => {
+  const response = await authFetch(`${API_BASE_URL}/weekly-plan?mealsPerDay=${mealsPerDay}`);
+  if (!response.ok) {
+    const errorBody = await response.text();
+    throw new Error(errorBody || 'Failed to generate weekly plan');
+  }
+  return response.json();
+};
+
+export const saveWeeklyPlan = async (plan: WeeklyPlanResponse): Promise<SavedWeeklyPlanResponse> => {
+  const response = await authFetch(`${API_BASE_URL}/weekly-plan/save`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(plan),
+  });
+  if (!response.ok) {
+    const errorBody = await response.text();
+    throw new Error(errorBody || 'Failed to save weekly plan');
+  }
+  return response.json();
+};
+
+export const getWeeklyPlanHistory = async (): Promise<SavedWeeklyPlanResponse[]> => {
+  const response = await authFetch(`${API_BASE_URL}/weekly-plan/history`);
+  if (!response.ok) {
+    const errorBody = await response.text();
+    throw new Error(errorBody || 'Failed to fetch weekly plan history');
+  }
+  return response.json();
+};
+
+export const generateShoppingList = async (mealIds: string[]): Promise<ShoppingListResponse> => {
+  const response = await authFetch(`${API_BASE_URL}/shopping-list`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ mealIds }),
+  });
+  if (!response.ok) {
+    const errorBody = await response.text();
+    throw new Error(errorBody || 'Failed to generate shopping list');
+  }
+  return response.json();
+};
+
+export const saveShoppingList = async (list: ShoppingListResponse): Promise<SavedShoppingListResponse> => {
+  const response = await authFetch(`${API_BASE_URL}/shopping-list/save`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(list),
+  });
+  if (!response.ok) {
+    const errorBody = await response.text();
+    throw new Error(errorBody || 'Failed to save shopping list');
+  }
+  return response.json();
+};
+
+export const getShoppingListHistory = async (): Promise<SavedShoppingListResponse[]> => {
+  const response = await authFetch(`${API_BASE_URL}/shopping-list/history`);
+  if (!response.ok) {
+    const errorBody = await response.text();
+    throw new Error(errorBody || 'Failed to fetch shopping list history');
+  }
+  return response.json();
+};
+
+export const deleteWeeklyPlan = async (weeklyPlanId: string): Promise<void> => {
+  const response = await authFetch(`${API_BASE_URL}/weekly-plan/${weeklyPlanId}`, {
+    method: 'DELETE',
+  });
+  if (!response.ok) {
+    const errorBody = await response.text();
+    throw new Error(errorBody || 'Failed to delete weekly plan');
+  }
+};
+
+export const generateShoppingListFromPlan = async (weeklyPlanId: string): Promise<ShoppingListResponse> => {
+  const response = await authFetch(`${API_BASE_URL}/shopping-list/from-plan/${weeklyPlanId}`, {
+    method: 'POST',
+  });
+  if (!response.ok) {
+    const errorBody = await response.text();
+    throw new Error(errorBody || 'Failed to generate shopping list from plan');
+  }
+  return response.json();
+};

--- a/frontend/src/types/mealPlanner.ts
+++ b/frontend/src/types/mealPlanner.ts
@@ -1,0 +1,37 @@
+export interface MealItem {
+  id: string;
+  name: string;
+  thumbnailUrl: string;
+}
+
+export interface DayPlan {
+  day: string;
+  meals: MealItem[];
+}
+
+export interface WeeklyPlanResponse {
+  days: DayPlan[];
+}
+
+export interface SavedWeeklyPlanResponse {
+  id: string;
+  createdAt: string;
+  mealsPerDay: number;
+  days: DayPlan[];
+}
+
+export interface ShoppingListItem {
+  name: string;
+  measures: string[];
+  recipes: string[];
+}
+
+export interface ShoppingListResponse {
+  items: ShoppingListItem[];
+}
+
+export interface SavedShoppingListResponse {
+  id: string;
+  createdAt: string;
+  items: ShoppingListItem[];
+}

--- a/meal-planner-service/MEAL_PLANNING.md
+++ b/meal-planner-service/MEAL_PLANNING.md
@@ -2,29 +2,74 @@
 
 ## Generowanie planu tygodniowego
 
+### Algorytm oparty na slotach
+
+Każdy dzień tygodnia jest budowany ze z góry określonych **slotów posiłków**, które zależą od parametru `mealsPerDay`. Slot determinuje kategorię, z której losowany jest jeden posiłek.
+
+#### Mapowanie slotów na liczbę posiłków
+
+| `mealsPerDay` | Sloty (w kolejności)                              |
+|:---:|:----------------------------------------------------|
+| 1   | MAIN                                               |
+| 2   | BREAKFAST, MAIN                                    |
+| 3   | BREAKFAST, MAIN, STARTER                           |
+| 4   | BREAKFAST, MAIN, SIDE, DESSERT                     |
+| 5   | BREAKFAST, MAIN, STARTER, SIDE, DESSERT            |
+
+#### Mapowanie slotów na kategorie TheMealDB
+
+| Slot      | Kategoria TheMealDB                                              |
+|-----------|------------------------------------------------------------------|
+| BREAKFAST | `Breakfast`                                                      |
+| DESSERT   | `Dessert`                                                        |
+| STARTER   | `Starter`                                                        |
+| SIDE      | `Side`                                                           |
+| MAIN      | losowa kategoria **spoza** {Breakfast, Dessert, Starter, Side}   |
+
+Slot MAIN czerpie z puli kategorii zwróconych przez endpoint kategorii (np. Beef, Chicken, Seafood, Pasta, Lamb, Pork, Vegetarian), wykluczając cztery stałe kategorie. Dla każdego dnia pula jest tasowana, co zapewnia różnorodność dań głównych w ciągu tygodnia.
+
+### Kroki algorytmu
+
 1. Walidacja parametru `mealsPerDay` (1–5); wartości spoza zakresu → `IllegalArgumentException` → 400.
 2. Wywołanie `GET /api/v1/discovery/categories` przez Feign Client (`MainServiceClient.getCategories()`).
    - Brak odpowiedzi / błąd sieci → `MainServiceCommunicationException` → 503.
    - Pusta lista kategorii → `MealPlanGenerationException` → 500.
-3. Dla każdego z 7 dni (poniedziałek–niedziela):
-   - losowanie kategorii z pełnej listy (`Collections.shuffle` + pick),
-   - wywołanie `GET /api/v1/discovery/filter/category?c={category}` → lista posiłków tej kategorii,
-   - losowanie `mealsPerDay` posiłków z listy (bez powtórzeń w ramach dnia),
-   - jeśli kategoria nie ma posiłków — dzień dostaje pustą listę (WARN w logach).
-4. Zwrot `WeeklyPlanResponse` z listą 7 obiektów `DayPlan`, każdy z polem `day` i listą `MealItem`.
+3. Filtrowanie kategorii: kategorie stałe (Breakfast, Dessert, Starter, Side) są wykluczane z puli MAIN.
+   - Brak kategorii głównych po filtrowaniu → `MealPlanGenerationException` → 500.
+4. Dla każdego z 7 dni (poniedziałek–niedziela):
+   - Tasowanie puli kategorii MAIN (zapewnia różnorodność dań głównych między dniami).
+   - Dla każdego slotu z listy przypisanej do `mealsPerDay`:
+     - MAIN → kategoria to pierwszy element potasowanej puli,
+     - pozostałe sloty → stała kategoria z mapy slot→kategoria,
+     - wywołanie `GET /api/v1/discovery/filter/category?c={category}` → lista posiłków,
+     - losowanie jednego posiłku z listy,
+     - jeśli kategoria nie ma posiłków → WARN w logach, slot jest pomijany.
+5. Zwrot `WeeklyPlanResponse` z listą 7 obiektów `DayPlan`, każdy z polem `day` i listą `MealItem`.
+
+### Diagram
 
 ```
 getCategories()
      │
      ▼
+filtruj kategorie MAIN (wyklucz: Breakfast, Dessert, Starter, Side)
+     │
+     ▼
 dla każdego dnia (×7):
-  losuj kategorię → getMealsByCategory(category) → losuj n posiłków
+  tasuj pulę MAIN
+  dla każdego slotu z listy dla mealsPerDay:
+    wyznacz kategorię (stała lub losowa MAIN)
+    getMealsByCategory(kategoria) → losuj 1 posiłek
      │
      ▼
 WeeklyPlanResponse { days: [ DayPlan, ... ] }
 ```
 
+---
+
 ## Generowanie listy zakupów
+
+### Z podanych ID posiłków (`POST /api/planner/shopping-list`)
 
 1. Klient przesyła `ShoppingListRequest` z listą `mealIds`.
 2. Dla każdego `mealId`:
@@ -36,13 +81,20 @@ WeeklyPlanResponse { days: [ DayPlan, ... ] }
    - odczyt odpowiadającej miary `strMeasure1`–`strMeasure20`.
 4. Deduplicacja po nazwie składnika (case-sensitive, dokładne dopasowanie):
    - pierwsze wystąpienie → nowy wpis w mapie (`LinkedHashMap` zachowuje kolejność wstawienia),
-   - kolejne wystąpienie tego samego składnika (z innego przepisu lub z innego slotu tego samego przepisu):
+   - kolejne wystąpienie tego samego składnika:
      - miara dodawana do listy `measures`,
-     - nazwa przepisu dodawana do listy `recipes` **tylko jeśli jeszcze jej tam nie ma** (zapobiega duplikatom gdy TheMealDB wymienia ten sam składnik w dwóch slotach jednego przepisu).
+     - nazwa przepisu dodawana do listy `recipes` **tylko jeśli jeszcze jej tam nie ma**.
 5. Zwrot `ShoppingListResponse` z listą `ShoppingListItem`:
    - `name` — nazwa składnika,
    - `measures` — wszystkie miary zebrane ze wszystkich przepisów,
    - `recipes` — unikalne nazwy przepisów, które używają tego składnika.
+
+### Z zapisanego planu tygodniowego (`POST /api/planner/shopping-list/from-plan/{weeklyPlanId}`)
+
+1. Weryfikacja właściciela: plan wyszukiwany po `weeklyPlanId` AND `userId` z JWT.
+   - Brak planu lub plan należy do innego użytkownika → `WeeklyPlanNotFoundException` → 404.
+2. Ekstrakcja listy `mealId` ze wszystkich encji `WeeklyPlanMeal` należących do planu.
+3. Dalej jak w punkcie 2–5 powyżej (reużycie `ShoppingListService.buildShoppingList`).
 
 ```
 mealIds: ["52772", "52884"]

--- a/meal-planner-service/pom.xml
+++ b/meal-planner-service/pom.xml
@@ -41,6 +41,17 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+
+        <!-- JPA & Database -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
@@ -101,6 +112,11 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/meal-planner-service/src/main/java/com/cookmate/mealplanner/controller/MealPlanController.java
+++ b/meal-planner-service/src/main/java/com/cookmate/mealplanner/controller/MealPlanController.java
@@ -22,6 +22,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,6 +30,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/planner")
@@ -77,6 +79,19 @@ public class MealPlanController {
                  content = @Content(schema = @Schema(implementation = ShoppingListResponse.class)))
     public ResponseEntity<ShoppingListResponse> getShoppingList(@RequestBody ShoppingListRequest request) {
         return ResponseEntity.ok(shoppingListService.buildShoppingList(request));
+    }
+
+    @PostMapping("/shopping-list/from-plan/{weeklyPlanId}")
+    @Operation(summary = "Generate shopping list from saved plan",
+               description = "Looks up a saved weekly plan by id and builds a shopping list from its meals.")
+    @ApiResponse(responseCode = "200", description = "Shopping list generated",
+                 content = @Content(schema = @Schema(implementation = ShoppingListResponse.class)))
+    @ApiResponse(responseCode = "404", description = "Weekly plan not found or not owned by user")
+    public ResponseEntity<ShoppingListResponse> generateShoppingListFromPlan(
+            @PathVariable UUID weeklyPlanId,
+            @AuthenticationPrincipal Jwt jwt) {
+        List<String> mealIds = weeklyPlanPersistenceService.getMealIds(weeklyPlanId, jwt.getSubject());
+        return ResponseEntity.ok(shoppingListService.buildShoppingList(new ShoppingListRequest(mealIds)));
     }
 
     @PostMapping("/shopping-list/save")

--- a/meal-planner-service/src/main/java/com/cookmate/mealplanner/controller/MealPlanController.java
+++ b/meal-planner-service/src/main/java/com/cookmate/mealplanner/controller/MealPlanController.java
@@ -1,10 +1,14 @@
 package com.cookmate.mealplanner.controller;
 
+import com.cookmate.mealplanner.dto.SavedShoppingListResponse;
+import com.cookmate.mealplanner.dto.SavedWeeklyPlanResponse;
 import com.cookmate.mealplanner.dto.ShoppingListRequest;
 import com.cookmate.mealplanner.dto.ShoppingListResponse;
 import com.cookmate.mealplanner.dto.WeeklyPlanResponse;
 import com.cookmate.mealplanner.service.MealPlanService;
+import com.cookmate.mealplanner.service.ShoppingListPersistenceService;
 import com.cookmate.mealplanner.service.ShoppingListService;
+import com.cookmate.mealplanner.service.WeeklyPlanPersistenceService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -14,6 +18,8 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -22,15 +28,19 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/planner")
 @RequiredArgsConstructor
 @Validated
-@Tag(name = "Meal Planner", description = "Weekly meal plan generation endpoints")
+@Tag(name = "Meal Planner", description = "Weekly meal plan generation and persistence endpoints")
 public class MealPlanController {
 
     private final MealPlanService mealPlanService;
     private final ShoppingListService shoppingListService;
+    private final WeeklyPlanPersistenceService weeklyPlanPersistenceService;
+    private final ShoppingListPersistenceService shoppingListPersistenceService;
 
     @GetMapping("/weekly-plan")
     @Operation(summary = "Generate weekly meal plan",
@@ -41,6 +51,25 @@ public class MealPlanController {
         return ResponseEntity.ok(mealPlanService.generateWeeklyPlan(mealsPerDay));
     }
 
+    @PostMapping("/weekly-plan/save")
+    @Operation(summary = "Save a weekly meal plan",
+               description = "Persists a previously generated weekly plan for the authenticated user.")
+    @ApiResponse(responseCode = "200", description = "Plan saved",
+                 content = @Content(schema = @Schema(implementation = SavedWeeklyPlanResponse.class)))
+    public ResponseEntity<SavedWeeklyPlanResponse> saveWeeklyPlan(
+            @RequestBody WeeklyPlanResponse request,
+            @AuthenticationPrincipal Jwt jwt) {
+        return ResponseEntity.ok(weeklyPlanPersistenceService.save(jwt.getSubject(), request));
+    }
+
+    @GetMapping("/weekly-plan/history")
+    @Operation(summary = "Get weekly plan history",
+               description = "Returns all saved weekly plans for the authenticated user, newest first.")
+    @ApiResponse(responseCode = "200", description = "History returned")
+    public ResponseEntity<List<SavedWeeklyPlanResponse>> getWeeklyPlanHistory(@AuthenticationPrincipal Jwt jwt) {
+        return ResponseEntity.ok(weeklyPlanPersistenceService.getHistory(jwt.getSubject()));
+    }
+
     @PostMapping("/shopping-list")
     @Operation(summary = "Build shopping list",
                description = "Returns a deduplicated shopping list for the given meal IDs.")
@@ -48,5 +77,24 @@ public class MealPlanController {
                  content = @Content(schema = @Schema(implementation = ShoppingListResponse.class)))
     public ResponseEntity<ShoppingListResponse> getShoppingList(@RequestBody ShoppingListRequest request) {
         return ResponseEntity.ok(shoppingListService.buildShoppingList(request));
+    }
+
+    @PostMapping("/shopping-list/save")
+    @Operation(summary = "Save a shopping list",
+               description = "Persists a previously generated shopping list for the authenticated user.")
+    @ApiResponse(responseCode = "200", description = "Shopping list saved",
+                 content = @Content(schema = @Schema(implementation = SavedShoppingListResponse.class)))
+    public ResponseEntity<SavedShoppingListResponse> saveShoppingList(
+            @RequestBody ShoppingListResponse request,
+            @AuthenticationPrincipal Jwt jwt) {
+        return ResponseEntity.ok(shoppingListPersistenceService.save(jwt.getSubject(), request));
+    }
+
+    @GetMapping("/shopping-list/history")
+    @Operation(summary = "Get shopping list history",
+               description = "Returns all saved shopping lists for the authenticated user, newest first.")
+    @ApiResponse(responseCode = "200", description = "History returned")
+    public ResponseEntity<List<SavedShoppingListResponse>> getShoppingListHistory(@AuthenticationPrincipal Jwt jwt) {
+        return ResponseEntity.ok(shoppingListPersistenceService.getHistory(jwt.getSubject()));
     }
 }

--- a/meal-planner-service/src/main/java/com/cookmate/mealplanner/controller/MealPlanController.java
+++ b/meal-planner-service/src/main/java/com/cookmate/mealplanner/controller/MealPlanController.java
@@ -21,6 +21,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -70,6 +71,18 @@ public class MealPlanController {
     @ApiResponse(responseCode = "200", description = "History returned")
     public ResponseEntity<List<SavedWeeklyPlanResponse>> getWeeklyPlanHistory(@AuthenticationPrincipal Jwt jwt) {
         return ResponseEntity.ok(weeklyPlanPersistenceService.getHistory(jwt.getSubject()));
+    }
+
+    @DeleteMapping("/weekly-plan/{id}")
+    @Operation(summary = "Delete a saved weekly plan",
+               description = "Deletes a saved weekly plan owned by the authenticated user.")
+    @ApiResponse(responseCode = "204", description = "Plan deleted")
+    @ApiResponse(responseCode = "404", description = "Plan not found or not owned by user")
+    public ResponseEntity<Void> deleteWeeklyPlan(
+            @PathVariable UUID id,
+            @AuthenticationPrincipal Jwt jwt) {
+        weeklyPlanPersistenceService.delete(id, jwt.getSubject());
+        return ResponseEntity.noContent().build();
     }
 
     @PostMapping("/shopping-list")

--- a/meal-planner-service/src/main/java/com/cookmate/mealplanner/dto/SavedShoppingListResponse.java
+++ b/meal-planner-service/src/main/java/com/cookmate/mealplanner/dto/SavedShoppingListResponse.java
@@ -1,0 +1,7 @@
+package com.cookmate.mealplanner.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public record SavedShoppingListResponse(UUID id, LocalDateTime createdAt, List<ShoppingListItem> items) {}

--- a/meal-planner-service/src/main/java/com/cookmate/mealplanner/dto/SavedWeeklyPlanResponse.java
+++ b/meal-planner-service/src/main/java/com/cookmate/mealplanner/dto/SavedWeeklyPlanResponse.java
@@ -1,0 +1,7 @@
+package com.cookmate.mealplanner.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public record SavedWeeklyPlanResponse(UUID id, LocalDateTime createdAt, int mealsPerDay, List<DayPlan> days) {}

--- a/meal-planner-service/src/main/java/com/cookmate/mealplanner/exception/GlobalExceptionHandler.java
+++ b/meal-planner-service/src/main/java/com/cookmate/mealplanner/exception/GlobalExceptionHandler.java
@@ -33,6 +33,17 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
     }
 
+    @ExceptionHandler(WeeklyPlanNotFoundException.class)
+    public ResponseEntity<ErrorResponseDto> handleWeeklyPlanNotFoundException(
+            WeeklyPlanNotFoundException exception
+    ) {
+        ErrorResponseDto errorResponse = new ErrorResponseDto(
+                "WEEKLY_PLAN_NOT_FOUND",
+                exception.getMessage()
+        );
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponseDto> handleValidationException(MethodArgumentNotValidException exception) {
         String message = exception.getBindingResult().getFieldErrors().stream()

--- a/meal-planner-service/src/main/java/com/cookmate/mealplanner/exception/WeeklyPlanNotFoundException.java
+++ b/meal-planner-service/src/main/java/com/cookmate/mealplanner/exception/WeeklyPlanNotFoundException.java
@@ -1,0 +1,8 @@
+package com.cookmate.mealplanner.exception;
+
+public class WeeklyPlanNotFoundException extends RuntimeException {
+
+    public WeeklyPlanNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/meal-planner-service/src/main/java/com/cookmate/mealplanner/model/ShoppingList.java
+++ b/meal-planner-service/src/main/java/com/cookmate/mealplanner/model/ShoppingList.java
@@ -1,0 +1,51 @@
+package com.cookmate.mealplanner.model;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "shopping_lists", indexes = {
+        @Index(name = "idx_shopping_lists_user_id", columnList = "user_id")
+})
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class ShoppingList {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(nullable = false, updatable = false)
+    private UUID id;
+
+    @Column(name = "user_id", nullable = false, length = 36)
+    private String userId;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @OneToMany(mappedBy = "shoppingList", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ShoppingListItemEntity> items = new ArrayList<>();
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+    }
+}

--- a/meal-planner-service/src/main/java/com/cookmate/mealplanner/model/ShoppingListItemEntity.java
+++ b/meal-planner-service/src/main/java/com/cookmate/mealplanner/model/ShoppingListItemEntity.java
@@ -1,0 +1,47 @@
+package com.cookmate.mealplanner.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "shopping_list_items", indexes = {
+        @Index(name = "idx_shopping_list_items_list_id", columnList = "shopping_list_id")
+})
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class ShoppingListItemEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(nullable = false, updatable = false)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "shopping_list_id", nullable = false)
+    private ShoppingList shoppingList;
+
+    @Column(name = "ingredient_name", nullable = false)
+    private String ingredientName;
+
+    @Column(columnDefinition = "TEXT")
+    private String measures;
+
+    @Column(name = "recipe_names", columnDefinition = "TEXT")
+    private String recipeNames;
+}

--- a/meal-planner-service/src/main/java/com/cookmate/mealplanner/model/WeeklyPlan.java
+++ b/meal-planner-service/src/main/java/com/cookmate/mealplanner/model/WeeklyPlan.java
@@ -1,0 +1,54 @@
+package com.cookmate.mealplanner.model;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "weekly_plans", indexes = {
+        @Index(name = "idx_weekly_plans_user_id", columnList = "user_id")
+})
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class WeeklyPlan {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(nullable = false, updatable = false)
+    private UUID id;
+
+    @Column(name = "user_id", nullable = false, length = 36)
+    private String userId;
+
+    @Column(name = "meals_per_day", nullable = false)
+    private int mealsPerDay;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @OneToMany(mappedBy = "weeklyPlan", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<WeeklyPlanMeal> meals = new ArrayList<>();
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+    }
+}

--- a/meal-planner-service/src/main/java/com/cookmate/mealplanner/model/WeeklyPlanMeal.java
+++ b/meal-planner-service/src/main/java/com/cookmate/mealplanner/model/WeeklyPlanMeal.java
@@ -1,0 +1,50 @@
+package com.cookmate.mealplanner.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "weekly_plan_meals", indexes = {
+        @Index(name = "idx_weekly_plan_meals_plan_id", columnList = "weekly_plan_id")
+})
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class WeeklyPlanMeal {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(nullable = false, updatable = false)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "weekly_plan_id", nullable = false)
+    private WeeklyPlan weeklyPlan;
+
+    @Column(name = "day_name", nullable = false, length = 20)
+    private String dayName;
+
+    @Column(name = "meal_id", nullable = false)
+    private String mealId;
+
+    @Column(name = "meal_name", nullable = false)
+    private String mealName;
+
+    @Column(name = "thumbnail_url")
+    private String thumbnailUrl;
+}

--- a/meal-planner-service/src/main/java/com/cookmate/mealplanner/repository/ShoppingListRepository.java
+++ b/meal-planner-service/src/main/java/com/cookmate/mealplanner/repository/ShoppingListRepository.java
@@ -1,11 +1,16 @@
 package com.cookmate.mealplanner.repository;
 
 import com.cookmate.mealplanner.model.ShoppingList;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.UUID;
 
 @Repository
 public interface ShoppingListRepository extends JpaRepository<ShoppingList, UUID> {
+
+    @EntityGraph(attributePaths = "items")
+    List<ShoppingList> findByUserIdOrderByCreatedAtDesc(String userId);
 }

--- a/meal-planner-service/src/main/java/com/cookmate/mealplanner/repository/ShoppingListRepository.java
+++ b/meal-planner-service/src/main/java/com/cookmate/mealplanner/repository/ShoppingListRepository.java
@@ -1,0 +1,11 @@
+package com.cookmate.mealplanner.repository;
+
+import com.cookmate.mealplanner.model.ShoppingList;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface ShoppingListRepository extends JpaRepository<ShoppingList, UUID> {
+}

--- a/meal-planner-service/src/main/java/com/cookmate/mealplanner/repository/WeeklyPlanRepository.java
+++ b/meal-planner-service/src/main/java/com/cookmate/mealplanner/repository/WeeklyPlanRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
@@ -13,4 +14,7 @@ public interface WeeklyPlanRepository extends JpaRepository<WeeklyPlan, UUID> {
 
     @EntityGraph(attributePaths = "meals")
     List<WeeklyPlan> findByUserIdOrderByCreatedAtDesc(String userId);
+
+    @EntityGraph(attributePaths = "meals")
+    Optional<WeeklyPlan> findByIdAndUserId(UUID id, String userId);
 }

--- a/meal-planner-service/src/main/java/com/cookmate/mealplanner/repository/WeeklyPlanRepository.java
+++ b/meal-planner-service/src/main/java/com/cookmate/mealplanner/repository/WeeklyPlanRepository.java
@@ -1,0 +1,11 @@
+package com.cookmate.mealplanner.repository;
+
+import com.cookmate.mealplanner.model.WeeklyPlan;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface WeeklyPlanRepository extends JpaRepository<WeeklyPlan, UUID> {
+}

--- a/meal-planner-service/src/main/java/com/cookmate/mealplanner/repository/WeeklyPlanRepository.java
+++ b/meal-planner-service/src/main/java/com/cookmate/mealplanner/repository/WeeklyPlanRepository.java
@@ -1,11 +1,16 @@
 package com.cookmate.mealplanner.repository;
 
 import com.cookmate.mealplanner.model.WeeklyPlan;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.UUID;
 
 @Repository
 public interface WeeklyPlanRepository extends JpaRepository<WeeklyPlan, UUID> {
+
+    @EntityGraph(attributePaths = "meals")
+    List<WeeklyPlan> findByUserIdOrderByCreatedAtDesc(String userId);
 }

--- a/meal-planner-service/src/main/java/com/cookmate/mealplanner/service/MealPlanService.java
+++ b/meal-planner-service/src/main/java/com/cookmate/mealplanner/service/MealPlanService.java
@@ -16,15 +16,38 @@ import org.springframework.stereotype.Service;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class MealPlanService {
 
+    private enum Slot { BREAKFAST, MAIN, STARTER, SIDE, DESSERT }
+
     private static final List<String> DAYS = List.of(
             "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"
     );
+
+    private static final Set<String> FIXED_CATEGORIES = Set.of("Breakfast", "Dessert", "Starter", "Side");
+
+    private static final Map<Slot, String> SLOT_TO_CATEGORY = Map.of(
+            Slot.BREAKFAST, "Breakfast",
+            Slot.DESSERT,   "Dessert",
+            Slot.STARTER,   "Starter",
+            Slot.SIDE,      "Side"
+    );
+
+    private static final Map<Integer, List<Slot>> SLOTS_BY_MEALS_PER_DAY = Map.of(
+            1, List.of(Slot.MAIN),
+            2, List.of(Slot.BREAKFAST, Slot.MAIN),
+            3, List.of(Slot.BREAKFAST, Slot.MAIN, Slot.STARTER),
+            4, List.of(Slot.BREAKFAST, Slot.MAIN, Slot.SIDE, Slot.DESSERT),
+            5, List.of(Slot.BREAKFAST, Slot.MAIN, Slot.STARTER, Slot.SIDE, Slot.DESSERT)
+    );
+
     private static final Logger logger = LoggerFactory.getLogger(MealPlanService.class);
 
     private final MainServiceClient mainServiceClient;
@@ -52,20 +75,37 @@ public class MealPlanService {
 
         logger.debug("Fetched {} categories from main-service", categories.size());
 
-        List<CategoryResponse.Category> shuffled = new ArrayList<>(categories);
-        Collections.shuffle(shuffled, random);
+        List<String> mainCategories = categories.stream()
+                .map(CategoryResponse.Category::name)
+                .filter(name -> !FIXED_CATEGORIES.contains(name))
+                .collect(Collectors.toCollection(ArrayList::new));
+
+        if (mainCategories.isEmpty()) {
+            logger.error("No main course categories available from main-service");
+            throw new MealPlanGenerationException("No main course categories available from main-service");
+        }
+
+        List<Slot> slots = SLOTS_BY_MEALS_PER_DAY.get(mealsPerDay);
 
         List<DayPlan> dayPlans = new ArrayList<>();
-        for (int i = 0; i < 7; i++) {
-            String category = shuffled.get(i % shuffled.size()).name();
-            dayPlans.add(new DayPlan(DAYS.get(i), pickMeals(category, mealsPerDay)));
+        for (String day : DAYS) {
+            Collections.shuffle(mainCategories, random);
+            List<MealItem> meals = new ArrayList<>();
+            for (Slot slot : slots) {
+                String category = slot == Slot.MAIN ? mainCategories.get(0) : SLOT_TO_CATEGORY.get(slot);
+                MealItem meal = pickOneMeal(category);
+                if (meal != null) {
+                    meals.add(meal);
+                }
+            }
+            dayPlans.add(new DayPlan(day, meals));
         }
 
         logger.info("Weekly plan generated successfully");
         return new WeeklyPlanResponse(dayPlans);
     }
 
-    private List<MealItem> pickMeals(String category, int count) {
+    private MealItem pickOneMeal(String category) {
         MealSearchResponse response;
         try {
             response = mainServiceClient.getMealsByCategory(category);
@@ -77,15 +117,11 @@ public class MealPlanService {
 
         if (response == null || response.meals() == null || response.meals().isEmpty()) {
             logger.warn("No meals found for category={}", category);
-            return List.of();
+            return null;
         }
 
         List<MealSearchResponse.FilteredMeal> all = new ArrayList<>(response.meals());
-        Collections.shuffle(all, random);
-
-        return all.stream()
-                .limit(count)
-                .map(m -> new MealItem(m.idMeal(), m.strMeal(), m.strMealThumb()))
-                .toList();
+        MealSearchResponse.FilteredMeal picked = all.get(random.nextInt(all.size()));
+        return new MealItem(picked.idMeal(), picked.strMeal(), picked.strMealThumb());
     }
 }

--- a/meal-planner-service/src/main/java/com/cookmate/mealplanner/service/ShoppingListPersistenceService.java
+++ b/meal-planner-service/src/main/java/com/cookmate/mealplanner/service/ShoppingListPersistenceService.java
@@ -1,0 +1,95 @@
+package com.cookmate.mealplanner.service;
+
+import com.cookmate.mealplanner.dto.SavedShoppingListResponse;
+import com.cookmate.mealplanner.dto.ShoppingListItem;
+import com.cookmate.mealplanner.dto.ShoppingListResponse;
+import com.cookmate.mealplanner.model.ShoppingList;
+import com.cookmate.mealplanner.model.ShoppingListItemEntity;
+import com.cookmate.mealplanner.repository.ShoppingListRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ShoppingListPersistenceService {
+
+    private static final Logger logger = LoggerFactory.getLogger(ShoppingListPersistenceService.class);
+    private static final TypeReference<List<String>> STRING_LIST = new TypeReference<>() {};
+
+    private final ShoppingListRepository shoppingListRepository;
+    private final ObjectMapper objectMapper;
+
+    @Transactional
+    public SavedShoppingListResponse save(String userId, ShoppingListResponse request) {
+        logger.info("Saving shopping list for userId={}, items={}", userId, request.items().size());
+
+        ShoppingList list = new ShoppingList();
+        list.setUserId(userId);
+
+        List<ShoppingListItemEntity> items = request.items().stream()
+                .map(item -> toEntity(item, list))
+                .toList();
+        list.setItems(items);
+
+        ShoppingList saved = shoppingListRepository.save(list);
+        logger.info("Shopping list saved with id={} for userId={}", saved.getId(), userId);
+        return toResponse(saved);
+    }
+
+    @Transactional(readOnly = true)
+    public List<SavedShoppingListResponse> getHistory(String userId) {
+        logger.info("Fetching shopping list history for userId={}", userId);
+        List<ShoppingList> lists = shoppingListRepository.findByUserIdOrderByCreatedAtDesc(userId);
+        logger.info("Found {} shopping lists for userId={}", lists.size(), userId);
+        return lists.stream().map(this::toResponse).toList();
+    }
+
+    private ShoppingListItemEntity toEntity(ShoppingListItem item, ShoppingList list) {
+        ShoppingListItemEntity entity = new ShoppingListItemEntity();
+        entity.setShoppingList(list);
+        entity.setIngredientName(item.name());
+        entity.setMeasures(toJson(item.measures()));
+        entity.setRecipeNames(toJson(item.recipes()));
+        return entity;
+    }
+
+    private SavedShoppingListResponse toResponse(ShoppingList list) {
+        List<ShoppingListItem> items = list.getItems().stream()
+                .map(item -> new ShoppingListItem(
+                        item.getIngredientName(),
+                        fromJson(item.getMeasures()),
+                        fromJson(item.getRecipeNames())
+                ))
+                .toList();
+        return new SavedShoppingListResponse(list.getId(), list.getCreatedAt(), items);
+    }
+
+    private String toJson(List<String> values) {
+        try {
+            return objectMapper.writeValueAsString(values);
+        } catch (JsonProcessingException e) {
+            logger.error("Failed to serialize list to JSON", e);
+            return "[]";
+        }
+    }
+
+    private List<String> fromJson(String json) {
+        if (json == null || json.isBlank()) {
+            return List.of();
+        }
+        try {
+            return objectMapper.readValue(json, STRING_LIST);
+        } catch (JsonProcessingException e) {
+            logger.error("Failed to deserialize JSON to list: {}", json, e);
+            return List.of();
+        }
+    }
+}

--- a/meal-planner-service/src/main/java/com/cookmate/mealplanner/service/WeeklyPlanPersistenceService.java
+++ b/meal-planner-service/src/main/java/com/cookmate/mealplanner/service/WeeklyPlanPersistenceService.java
@@ -1,0 +1,85 @@
+package com.cookmate.mealplanner.service;
+
+import com.cookmate.mealplanner.dto.DayPlan;
+import com.cookmate.mealplanner.dto.MealItem;
+import com.cookmate.mealplanner.dto.SavedWeeklyPlanResponse;
+import com.cookmate.mealplanner.dto.WeeklyPlanResponse;
+import com.cookmate.mealplanner.model.WeeklyPlan;
+import com.cookmate.mealplanner.model.WeeklyPlanMeal;
+import com.cookmate.mealplanner.repository.WeeklyPlanRepository;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class WeeklyPlanPersistenceService {
+
+    private static final Logger logger = LoggerFactory.getLogger(WeeklyPlanPersistenceService.class);
+    private static final List<String> ORDERED_DAYS = List.of(
+            "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"
+    );
+
+    private final WeeklyPlanRepository weeklyPlanRepository;
+
+    @Transactional
+    public SavedWeeklyPlanResponse save(String userId, WeeklyPlanResponse request) {
+        logger.info("Saving weekly plan for userId={}", userId);
+
+        WeeklyPlan plan = new WeeklyPlan();
+        plan.setUserId(userId);
+        plan.setMealsPerDay(request.days().stream()
+                .mapToInt(d -> d.meals().size())
+                .max()
+                .orElse(0));
+
+        List<WeeklyPlanMeal> meals = new ArrayList<>();
+        for (DayPlan day : request.days()) {
+            for (MealItem meal : day.meals()) {
+                WeeklyPlanMeal entity = new WeeklyPlanMeal();
+                entity.setWeeklyPlan(plan);
+                entity.setDayName(day.day());
+                entity.setMealId(meal.id());
+                entity.setMealName(meal.name());
+                entity.setThumbnailUrl(meal.thumbnailUrl());
+                meals.add(entity);
+            }
+        }
+        plan.setMeals(meals);
+
+        WeeklyPlan saved = weeklyPlanRepository.save(plan);
+        logger.info("Weekly plan saved with id={} for userId={}", saved.getId(), userId);
+        return toResponse(saved);
+    }
+
+    @Transactional(readOnly = true)
+    public List<SavedWeeklyPlanResponse> getHistory(String userId) {
+        logger.info("Fetching weekly plan history for userId={}", userId);
+        List<WeeklyPlan> plans = weeklyPlanRepository.findByUserIdOrderByCreatedAtDesc(userId);
+        logger.info("Found {} weekly plans for userId={}", plans.size(), userId);
+        return plans.stream().map(this::toResponse).toList();
+    }
+
+    private SavedWeeklyPlanResponse toResponse(WeeklyPlan plan) {
+        Map<String, List<MealItem>> mealsByDay = new LinkedHashMap<>();
+        ORDERED_DAYS.forEach(day -> mealsByDay.put(day, new ArrayList<>()));
+
+        for (WeeklyPlanMeal meal : plan.getMeals()) {
+            mealsByDay.computeIfAbsent(meal.getDayName(), k -> new ArrayList<>())
+                    .add(new MealItem(meal.getMealId(), meal.getMealName(), meal.getThumbnailUrl()));
+        }
+
+        List<DayPlan> days = mealsByDay.entrySet().stream()
+                .map(e -> new DayPlan(e.getKey(), e.getValue()))
+                .toList();
+
+        return new SavedWeeklyPlanResponse(plan.getId(), plan.getCreatedAt(), plan.getMealsPerDay(), days);
+    }
+}

--- a/meal-planner-service/src/main/java/com/cookmate/mealplanner/service/WeeklyPlanPersistenceService.java
+++ b/meal-planner-service/src/main/java/com/cookmate/mealplanner/service/WeeklyPlanPersistenceService.java
@@ -69,6 +69,16 @@ public class WeeklyPlanPersistenceService {
         return plans.stream().map(this::toResponse).toList();
     }
 
+    @Transactional
+    public void delete(UUID weeklyPlanId, String userId) {
+        logger.info("Deleting weeklyPlanId={} for userId={}", weeklyPlanId, userId);
+        WeeklyPlan plan = weeklyPlanRepository.findByIdAndUserId(weeklyPlanId, userId)
+                .orElseThrow(() -> new WeeklyPlanNotFoundException(
+                        "Weekly plan not found: " + weeklyPlanId));
+        weeklyPlanRepository.delete(plan);
+        logger.info("Deleted weeklyPlanId={} for userId={}", weeklyPlanId, userId);
+    }
+
     @Transactional(readOnly = true)
     public List<String> getMealIds(UUID weeklyPlanId, String userId) {
         logger.info("Fetching meal ids from weeklyPlanId={} for userId={}", weeklyPlanId, userId);

--- a/meal-planner-service/src/main/java/com/cookmate/mealplanner/service/WeeklyPlanPersistenceService.java
+++ b/meal-planner-service/src/main/java/com/cookmate/mealplanner/service/WeeklyPlanPersistenceService.java
@@ -4,6 +4,7 @@ import com.cookmate.mealplanner.dto.DayPlan;
 import com.cookmate.mealplanner.dto.MealItem;
 import com.cookmate.mealplanner.dto.SavedWeeklyPlanResponse;
 import com.cookmate.mealplanner.dto.WeeklyPlanResponse;
+import com.cookmate.mealplanner.exception.WeeklyPlanNotFoundException;
 import com.cookmate.mealplanner.model.WeeklyPlan;
 import com.cookmate.mealplanner.model.WeeklyPlanMeal;
 import com.cookmate.mealplanner.repository.WeeklyPlanRepository;
@@ -17,6 +18,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -65,6 +67,17 @@ public class WeeklyPlanPersistenceService {
         List<WeeklyPlan> plans = weeklyPlanRepository.findByUserIdOrderByCreatedAtDesc(userId);
         logger.info("Found {} weekly plans for userId={}", plans.size(), userId);
         return plans.stream().map(this::toResponse).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<String> getMealIds(UUID weeklyPlanId, String userId) {
+        logger.info("Fetching meal ids from weeklyPlanId={} for userId={}", weeklyPlanId, userId);
+        WeeklyPlan plan = weeklyPlanRepository.findByIdAndUserId(weeklyPlanId, userId)
+                .orElseThrow(() -> new WeeklyPlanNotFoundException(
+                        "Weekly plan not found: " + weeklyPlanId));
+        return plan.getMeals().stream()
+                .map(WeeklyPlanMeal::getMealId)
+                .toList();
     }
 
     private SavedWeeklyPlanResponse toResponse(WeeklyPlan plan) {

--- a/meal-planner-service/src/main/resources/schema.sql
+++ b/meal-planner-service/src/main/resources/schema.sql
@@ -1,0 +1,1 @@
+CREATE SCHEMA IF NOT EXISTS meal_planner;

--- a/meal-planner-service/src/test/java/com/cookmate/mealplanner/controller/MealPlanControllerTest.java
+++ b/meal-planner-service/src/test/java/com/cookmate/mealplanner/controller/MealPlanControllerTest.java
@@ -2,26 +2,40 @@ package com.cookmate.mealplanner.controller;
 
 import com.cookmate.mealplanner.client.MainServiceClient;
 import com.cookmate.mealplanner.dto.CategoryResponse;
+import com.cookmate.mealplanner.dto.DayPlan;
+import com.cookmate.mealplanner.dto.MealItem;
 import com.cookmate.mealplanner.dto.MealSearchResponse;
+import com.cookmate.mealplanner.dto.SavedShoppingListResponse;
+import com.cookmate.mealplanner.dto.SavedWeeklyPlanResponse;
+import com.cookmate.mealplanner.dto.ShoppingListItem;
+import com.cookmate.mealplanner.service.ShoppingListPersistenceService;
+import com.cookmate.mealplanner.service.WeeklyPlanPersistenceService;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -34,11 +48,20 @@ class MealPlanControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
+    @Autowired
+    private ObjectMapper objectMapper;
+
     @MockitoBean
     private MainServiceClient mainServiceClient;
 
     @MockitoBean
     private JwtDecoder jwtDecoder;
+
+    @MockitoBean
+    private WeeklyPlanPersistenceService weeklyPlanPersistenceService;
+
+    @MockitoBean
+    private ShoppingListPersistenceService shoppingListPersistenceService;
 
     // --- helpers ---
 
@@ -60,6 +83,29 @@ class MealPlanControllerTest {
         }
         when(mainServiceClient.getCategories()).thenReturn(categories);
         when(mainServiceClient.getMealsByCategory(anyString())).thenReturn(new MealSearchResponse(meals));
+    }
+
+    private SavedWeeklyPlanResponse savedWeeklyPlanResponse() {
+        UUID id = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        List<MealItem> meals = List.of(new MealItem("1", "Pasta", "https://thumb.jpg"));
+        List<DayPlan> days = List.of(
+                new DayPlan("Monday", meals),
+                new DayPlan("Tuesday", List.of()),
+                new DayPlan("Wednesday", List.of()),
+                new DayPlan("Thursday", List.of()),
+                new DayPlan("Friday", List.of()),
+                new DayPlan("Saturday", List.of()),
+                new DayPlan("Sunday", List.of())
+        );
+        return new SavedWeeklyPlanResponse(id, LocalDateTime.of(2026, 1, 10, 12, 0), 1, days);
+    }
+
+    private SavedShoppingListResponse savedShoppingListResponse() {
+        UUID id = UUID.fromString("00000000-0000-0000-0000-000000000002");
+        List<ShoppingListItem> items = List.of(
+                new ShoppingListItem("Salt", List.of("1 tsp"), List.of("Pasta"))
+        );
+        return new SavedShoppingListResponse(id, LocalDateTime.of(2026, 1, 10, 12, 0), items);
     }
 
     // --- GET /api/planner/weekly-plan ---
@@ -149,5 +195,173 @@ class MealPlanControllerTest {
                         .param("mealsPerDay", "2"))
                 .andExpect(status().isServiceUnavailable())
                 .andExpect(jsonPath("$.code").value("MAIN_SERVICE_UNAVAILABLE"));
+    }
+
+    // --- POST /api/planner/weekly-plan/save ---
+
+    @Test
+    @DisplayName("POST /weekly-plan/save — zapisuje plan i zwraca 200 z id")
+    void saveWeeklyPlan_validRequest_returns200WithId() throws Exception {
+        when(weeklyPlanPersistenceService.save(anyString(), any())).thenReturn(savedWeeklyPlanResponse());
+
+        List<DayPlan> days = List.of(new DayPlan("Monday", List.of(new MealItem("1", "Pasta", "https://t.jpg"))));
+        String body = objectMapper.writeValueAsString(new com.cookmate.mealplanner.dto.WeeklyPlanResponse(days));
+
+        mockMvc.perform(post("/api/planner/weekly-plan/save")
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER")))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value("00000000-0000-0000-0000-000000000001"))
+                .andExpect(jsonPath("$.mealsPerDay").value(1))
+                .andExpect(jsonPath("$.days", hasSize(7)));
+    }
+
+    @Test
+    @DisplayName("POST /weekly-plan/save — przekazuje userId z JWT do serwisu")
+    void saveWeeklyPlan_passesUserIdFromJwt() throws Exception {
+        when(weeklyPlanPersistenceService.save(eq("test-user-id"), any()))
+                .thenReturn(savedWeeklyPlanResponse());
+
+        List<DayPlan> days = List.of(new DayPlan("Monday", List.of()));
+        String body = objectMapper.writeValueAsString(new com.cookmate.mealplanner.dto.WeeklyPlanResponse(days));
+
+        mockMvc.perform(post("/api/planner/weekly-plan/save")
+                        .with(jwt().jwt(j -> j.subject("test-user-id"))
+                                .authorities(new SimpleGrantedAuthority("ROLE_USER")))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("POST /weekly-plan/save — brak JWT zwraca 401")
+    void saveWeeklyPlan_noJwt_returns401() throws Exception {
+        String body = objectMapper.writeValueAsString(
+                new com.cookmate.mealplanner.dto.WeeklyPlanResponse(List.of()));
+
+        mockMvc.perform(post("/api/planner/weekly-plan/save")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // --- GET /api/planner/weekly-plan/history ---
+
+    @Test
+    @DisplayName("GET /weekly-plan/history — zwraca historię planów dla użytkownika")
+    void getWeeklyPlanHistory_returns200WithHistory() throws Exception {
+        when(weeklyPlanPersistenceService.getHistory(anyString()))
+                .thenReturn(List.of(savedWeeklyPlanResponse()));
+
+        mockMvc.perform(get("/api/planner/weekly-plan/history")
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].id").value("00000000-0000-0000-0000-000000000001"));
+    }
+
+    @Test
+    @DisplayName("GET /weekly-plan/history — pusta historia zwraca pustą tablicę")
+    void getWeeklyPlanHistory_emptyHistory_returnsEmptyArray() throws Exception {
+        when(weeklyPlanPersistenceService.getHistory(anyString())).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/planner/weekly-plan/history")
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(0)));
+    }
+
+    @Test
+    @DisplayName("GET /weekly-plan/history — brak JWT zwraca 401")
+    void getWeeklyPlanHistory_noJwt_returns401() throws Exception {
+        mockMvc.perform(get("/api/planner/weekly-plan/history"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // --- POST /api/planner/shopping-list/save ---
+
+    @Test
+    @DisplayName("POST /shopping-list/save — zapisuje listę i zwraca 200 z id")
+    void saveShoppingList_validRequest_returns200WithId() throws Exception {
+        when(shoppingListPersistenceService.save(anyString(), any())).thenReturn(savedShoppingListResponse());
+
+        List<ShoppingListItem> items = List.of(
+                new ShoppingListItem("Salt", List.of("1 tsp"), List.of("Pasta"))
+        );
+        String body = objectMapper.writeValueAsString(
+                new com.cookmate.mealplanner.dto.ShoppingListResponse(items));
+
+        mockMvc.perform(post("/api/planner/shopping-list/save")
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER")))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value("00000000-0000-0000-0000-000000000002"))
+                .andExpect(jsonPath("$.items", hasSize(1)))
+                .andExpect(jsonPath("$.items[0].name").value("Salt"));
+    }
+
+    @Test
+    @DisplayName("POST /shopping-list/save — przekazuje userId z JWT do serwisu")
+    void saveShoppingList_passesUserIdFromJwt() throws Exception {
+        when(shoppingListPersistenceService.save(eq("test-user-id"), any()))
+                .thenReturn(savedShoppingListResponse());
+
+        String body = objectMapper.writeValueAsString(
+                new com.cookmate.mealplanner.dto.ShoppingListResponse(List.of()));
+
+        mockMvc.perform(post("/api/planner/shopping-list/save")
+                        .with(jwt().jwt(j -> j.subject("test-user-id"))
+                                .authorities(new SimpleGrantedAuthority("ROLE_USER")))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("POST /shopping-list/save — brak JWT zwraca 401")
+    void saveShoppingList_noJwt_returns401() throws Exception {
+        String body = objectMapper.writeValueAsString(
+                new com.cookmate.mealplanner.dto.ShoppingListResponse(List.of()));
+
+        mockMvc.perform(post("/api/planner/shopping-list/save")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // --- GET /api/planner/shopping-list/history ---
+
+    @Test
+    @DisplayName("GET /shopping-list/history — zwraca historię list zakupów")
+    void getShoppingListHistory_returns200WithHistory() throws Exception {
+        when(shoppingListPersistenceService.getHistory(anyString()))
+                .thenReturn(List.of(savedShoppingListResponse()));
+
+        mockMvc.perform(get("/api/planner/shopping-list/history")
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].id").value("00000000-0000-0000-0000-000000000002"))
+                .andExpect(jsonPath("$[0].items[0].name").value("Salt"));
+    }
+
+    @Test
+    @DisplayName("GET /shopping-list/history — pusta historia zwraca pustą tablicę")
+    void getShoppingListHistory_emptyHistory_returnsEmptyArray() throws Exception {
+        when(shoppingListPersistenceService.getHistory(anyString())).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/planner/shopping-list/history")
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(0)));
+    }
+
+    @Test
+    @DisplayName("GET /shopping-list/history — brak JWT zwraca 401")
+    void getShoppingListHistory_noJwt_returns401() throws Exception {
+        mockMvc.perform(get("/api/planner/shopping-list/history"))
+                .andExpect(status().isUnauthorized());
     }
 }

--- a/meal-planner-service/src/test/java/com/cookmate/mealplanner/controller/MealPlanControllerTest.java
+++ b/meal-planner-service/src/test/java/com/cookmate/mealplanner/controller/MealPlanControllerTest.java
@@ -3,11 +3,14 @@ package com.cookmate.mealplanner.controller;
 import com.cookmate.mealplanner.client.MainServiceClient;
 import com.cookmate.mealplanner.dto.CategoryResponse;
 import com.cookmate.mealplanner.dto.DayPlan;
+import com.cookmate.mealplanner.dto.MealDetailListResponse;
+import com.cookmate.mealplanner.dto.MealDetailResponse;
 import com.cookmate.mealplanner.dto.MealItem;
 import com.cookmate.mealplanner.dto.MealSearchResponse;
 import com.cookmate.mealplanner.dto.SavedShoppingListResponse;
 import com.cookmate.mealplanner.dto.SavedWeeklyPlanResponse;
 import com.cookmate.mealplanner.dto.ShoppingListItem;
+import com.cookmate.mealplanner.exception.WeeklyPlanNotFoundException;
 import com.cookmate.mealplanner.service.ShoppingListPersistenceService;
 import com.cookmate.mealplanner.service.WeeklyPlanPersistenceService;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -329,6 +332,78 @@ class MealPlanControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body))
                 .andExpect(status().isUnauthorized());
+    }
+
+    // --- POST /api/planner/shopping-list/from-plan/{weeklyPlanId} ---
+
+    @Test
+    @DisplayName("POST /shopping-list/from-plan/{id} — zwraca 200 z listą zakupów wygenerowaną z planu")
+    void generateShoppingListFromPlan_validPlan_returns200WithItems() throws Exception {
+        UUID planId = UUID.randomUUID();
+        when(weeklyPlanPersistenceService.getMealIds(eq(planId), anyString()))
+                .thenReturn(List.of("1"));
+
+        MealDetailResponse mealDetail = new MealDetailResponse();
+        mealDetail.setIdMeal("1");
+        mealDetail.setStrMeal("Pasta");
+        mealDetail.setStrIngredient1("Salt");
+        mealDetail.setStrMeasure1("1 tsp");
+        when(mainServiceClient.lookupById("1"))
+                .thenReturn(new MealDetailListResponse(List.of(mealDetail)));
+
+        mockMvc.perform(post("/api/planner/shopping-list/from-plan/" + planId)
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items", hasSize(1)))
+                .andExpect(jsonPath("$.items[0].name").value("Salt"))
+                .andExpect(jsonPath("$.items[0].measures[0]").value("1 tsp"));
+    }
+
+    @Test
+    @DisplayName("POST /shopping-list/from-plan/{id} — przekazuje userId z JWT do serwisu")
+    void generateShoppingListFromPlan_passesUserIdFromJwt() throws Exception {
+        UUID planId = UUID.randomUUID();
+        when(weeklyPlanPersistenceService.getMealIds(eq(planId), eq("test-user-id")))
+                .thenReturn(List.of());
+
+        mockMvc.perform(post("/api/planner/shopping-list/from-plan/" + planId)
+                        .with(jwt().jwt(j -> j.subject("test-user-id"))
+                                .authorities(new SimpleGrantedAuthority("ROLE_USER"))))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("POST /shopping-list/from-plan/{id} — plan nie istnieje zwraca 404")
+    void generateShoppingListFromPlan_planNotFound_returns404() throws Exception {
+        UUID planId = UUID.randomUUID();
+        when(weeklyPlanPersistenceService.getMealIds(eq(planId), anyString()))
+                .thenThrow(new WeeklyPlanNotFoundException("Weekly plan not found: " + planId));
+
+        mockMvc.perform(post("/api/planner/shopping-list/from-plan/" + planId)
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER"))))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("WEEKLY_PLAN_NOT_FOUND"))
+                .andExpect(jsonPath("$.message").value("Weekly plan not found: " + planId));
+    }
+
+    @Test
+    @DisplayName("POST /shopping-list/from-plan/{id} — brak JWT zwraca 401")
+    void generateShoppingListFromPlan_noJwt_returns401() throws Exception {
+        mockMvc.perform(post("/api/planner/shopping-list/from-plan/" + UUID.randomUUID()))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("POST /shopping-list/from-plan/{id} — plan bez posiłków zwraca pustą listę zakupów")
+    void generateShoppingListFromPlan_emptyPlan_returnsEmptyShoppingList() throws Exception {
+        UUID planId = UUID.randomUUID();
+        when(weeklyPlanPersistenceService.getMealIds(eq(planId), anyString()))
+                .thenReturn(List.of());
+
+        mockMvc.perform(post("/api/planner/shopping-list/from-plan/" + planId)
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items", hasSize(0)));
     }
 
     // --- GET /api/planner/shopping-list/history ---

--- a/meal-planner-service/src/test/java/com/cookmate/mealplanner/service/MealPlanServiceTest.java
+++ b/meal-planner-service/src/test/java/com/cookmate/mealplanner/service/MealPlanServiceTest.java
@@ -19,6 +19,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -42,13 +43,15 @@ class MealPlanServiceTest {
     private CategoryResponse mockCategories() {
         return new CategoryResponse(List.of(
                 new CategoryResponse.Category("1", "Beef"),
-                new CategoryResponse.Category("2", "Chicken"),
-                new CategoryResponse.Category("3", "Dessert"),
-                new CategoryResponse.Category("4", "Lamb"),
-                new CategoryResponse.Category("5", "Miscellaneous"),
+                new CategoryResponse.Category("2", "Breakfast"),
+                new CategoryResponse.Category("3", "Chicken"),
+                new CategoryResponse.Category("4", "Dessert"),
+                new CategoryResponse.Category("5", "Lamb"),
                 new CategoryResponse.Category("6", "Pasta"),
-                new CategoryResponse.Category("7", "Pork"),
-                new CategoryResponse.Category("8", "Seafood")
+                new CategoryResponse.Category("7", "Seafood"),
+                new CategoryResponse.Category("8", "Side"),
+                new CategoryResponse.Category("9", "Starter"),
+                new CategoryResponse.Category("10", "Pork")
         ));
     }
 
@@ -66,7 +69,7 @@ class MealPlanServiceTest {
         return new MealSearchResponse(List.of());
     }
 
-    // --- generateWeeklyPlan ---
+    // --- generateWeeklyPlan — shape ---
 
     @Test
     @DisplayName("generateWeeklyPlan — zwraca dokładnie 7 dni")
@@ -93,7 +96,7 @@ class MealPlanServiceTest {
     }
 
     @Test
-    @DisplayName("generateWeeklyPlan — każdy dzień ma dokładnie n posiłków")
+    @DisplayName("generateWeeklyPlan — każdy dzień ma dokładnie n posiłków gdy wszystkie kategorie zwracają dane")
     void generateWeeklyPlan_eachDayHasExactlyNMeals() {
         int mealsPerDay = 3;
         when(mainServiceClient.getCategories()).thenReturn(mockCategories());
@@ -107,8 +110,8 @@ class MealPlanServiceTest {
     }
 
     @Test
-    @DisplayName("generateWeeklyPlan — gdy kategoria nie ma posiłków, dzień dostaje pustą listę")
-    void generateWeeklyPlan_emptyCategory_dayGetsEmptyMealList() {
+    @DisplayName("generateWeeklyPlan — gdy kategoria nie ma posiłków, slot jest pomijany")
+    void generateWeeklyPlan_emptyCategory_slotIsSkipped() {
         when(mainServiceClient.getCategories()).thenReturn(mockCategories());
         when(mainServiceClient.getMealsByCategory(anyString())).thenReturn(emptyMeals());
 
@@ -131,14 +134,15 @@ class MealPlanServiceTest {
     }
 
     @Test
-    @DisplayName("generateWeeklyPlan — pobiera posiłki dla każdego z 7 dni")
-    void generateWeeklyPlan_fetchesMealsForEachDay() {
+    @DisplayName("generateWeeklyPlan — wywołuje getMealsByCategory tyle razy ile wynosi liczba slotów × 7 dni")
+    void generateWeeklyPlan_callsMealsByCategoryForEachSlotAndDay() {
         when(mainServiceClient.getCategories()).thenReturn(mockCategories());
         when(mainServiceClient.getMealsByCategory(anyString())).thenReturn(mockMeals(5));
 
+        // mealsPerDay=2 → 2 slots (BREAKFAST + MAIN) × 7 days = 14 calls
         mealPlanService.generateWeeklyPlan(2);
 
-        verify(mainServiceClient, times(7)).getMealsByCategory(anyString());
+        verify(mainServiceClient, times(14)).getMealsByCategory(anyString());
     }
 
     @Test
@@ -159,6 +163,56 @@ class MealPlanServiceTest {
         assertThatThrownBy(() -> mealPlanService.generateWeeklyPlan(1))
                 .isInstanceOf(MealPlanGenerationException.class)
                 .hasMessageContaining("No categories available");
+    }
+
+    // --- slot mapping ---
+
+    @Test
+    @DisplayName("mealsPerDay=1 — MAIN slot nie używa kategorii Breakfast, Dessert, Starter ani Side")
+    void generateWeeklyPlan_mealsPerDayOne_mainSlotNeverUsesFixedCategories() {
+        when(mainServiceClient.getCategories()).thenReturn(mockCategories());
+        when(mainServiceClient.getMealsByCategory(anyString())).thenReturn(mockMeals(5));
+
+        mealPlanService.generateWeeklyPlan(1);
+
+        verify(mainServiceClient, never()).getMealsByCategory("Breakfast");
+        verify(mainServiceClient, never()).getMealsByCategory("Dessert");
+        verify(mainServiceClient, never()).getMealsByCategory("Starter");
+        verify(mainServiceClient, never()).getMealsByCategory("Side");
+        // exactly 7 calls total (one MAIN per day)
+        verify(mainServiceClient, times(7)).getMealsByCategory(anyString());
+    }
+
+    @Test
+    @DisplayName("mealsPerDay=2 — BREAKFAST slot wywołuje 'Breakfast' 7 razy, MAIN nie używa stałych kategorii")
+    void generateWeeklyPlan_mealsPerDayTwo_breakfastSlotUsesBreakfastCategory() {
+        when(mainServiceClient.getCategories()).thenReturn(mockCategories());
+        when(mainServiceClient.getMealsByCategory(anyString())).thenReturn(mockMeals(5));
+
+        mealPlanService.generateWeeklyPlan(2);
+
+        verify(mainServiceClient, times(7)).getMealsByCategory("Breakfast");
+        verify(mainServiceClient, never()).getMealsByCategory("Dessert");
+        verify(mainServiceClient, never()).getMealsByCategory("Starter");
+        verify(mainServiceClient, never()).getMealsByCategory("Side");
+        // 2 slots × 7 days = 14 total
+        verify(mainServiceClient, times(14)).getMealsByCategory(anyString());
+    }
+
+    @Test
+    @DisplayName("mealsPerDay=5 — wszystkie 5 slotów mapują się na właściwe kategorie")
+    void generateWeeklyPlan_mealsPerDayFive_allSlotsUseCorrectCategories() {
+        when(mainServiceClient.getCategories()).thenReturn(mockCategories());
+        when(mainServiceClient.getMealsByCategory(anyString())).thenReturn(mockMeals(5));
+
+        mealPlanService.generateWeeklyPlan(5);
+
+        verify(mainServiceClient, times(7)).getMealsByCategory("Breakfast");
+        verify(mainServiceClient, times(7)).getMealsByCategory("Starter");
+        verify(mainServiceClient, times(7)).getMealsByCategory("Side");
+        verify(mainServiceClient, times(7)).getMealsByCategory("Dessert");
+        // 5 slots × 7 days = 35 total (4 fixed + 7 MAIN)
+        verify(mainServiceClient, times(35)).getMealsByCategory(anyString());
     }
 
     // --- validation ---

--- a/meal-planner-service/src/test/java/com/cookmate/mealplanner/service/ShoppingListPersistenceServiceTest.java
+++ b/meal-planner-service/src/test/java/com/cookmate/mealplanner/service/ShoppingListPersistenceServiceTest.java
@@ -1,0 +1,176 @@
+package com.cookmate.mealplanner.service;
+
+import com.cookmate.mealplanner.dto.SavedShoppingListResponse;
+import com.cookmate.mealplanner.dto.ShoppingListItem;
+import com.cookmate.mealplanner.dto.ShoppingListResponse;
+import com.cookmate.mealplanner.model.ShoppingList;
+import com.cookmate.mealplanner.model.ShoppingListItemEntity;
+import com.cookmate.mealplanner.repository.ShoppingListRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@DisplayName("ShoppingListPersistenceService — unit tests")
+class ShoppingListPersistenceServiceTest {
+
+    @Mock
+    private ShoppingListRepository shoppingListRepository;
+
+    private ShoppingListPersistenceService service;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        service = new ShoppingListPersistenceService(shoppingListRepository, new ObjectMapper());
+        when(shoppingListRepository.save(any(ShoppingList.class))).thenAnswer(invocation -> {
+            ShoppingList list = invocation.getArgument(0);
+            list.setId(UUID.fromString("00000000-0000-0000-0000-000000000001"));
+            return list;
+        });
+    }
+
+    // --- helpers ---
+
+    private ShoppingListResponse twoItemResponse() {
+        return new ShoppingListResponse(List.of(
+                new ShoppingListItem("Salt", List.of("1 tsp", "2 tsp"), List.of("Pasta", "Soup")),
+                new ShoppingListItem("Garlic", List.of("2 cloves"), List.of("Pasta"))
+        ));
+    }
+
+    private ShoppingList savedList(UUID id, String userId) {
+        ShoppingList list = new ShoppingList();
+        list.setId(id);
+        list.setUserId(userId);
+        list.setCreatedAt(LocalDateTime.of(2026, 1, 10, 12, 0));
+
+        ShoppingListItemEntity item = new ShoppingListItemEntity();
+        item.setShoppingList(list);
+        item.setIngredientName("Salt");
+        item.setMeasures("[\"1 tsp\",\"2 tsp\"]");
+        item.setRecipeNames("[\"Pasta\",\"Soup\"]");
+        list.setItems(List.of(item));
+        return list;
+    }
+
+    // --- save ---
+
+    @Test
+    @DisplayName("save — wywołuje repository.save")
+    void save_callsRepository() {
+        service.save("user-1", twoItemResponse());
+        verify(shoppingListRepository).save(any(ShoppingList.class));
+    }
+
+    @Test
+    @DisplayName("save — zwraca odpowiedź z wygenerowanym id")
+    void save_returnsResponseWithId() {
+        SavedShoppingListResponse response = service.save("user-1", twoItemResponse());
+        assertThat(response.id()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("save — zachowuje poprawną liczbę elementów")
+    void save_preservesItemCount() {
+        SavedShoppingListResponse response = service.save("user-1", twoItemResponse());
+        assertThat(response.items()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("save — miary są serializowane do JSON i poprawnie deserializowane w odpowiedzi")
+    void save_measuresAreSerializedAndDeserializedCorrectly() {
+        SavedShoppingListResponse response = service.save("user-1", twoItemResponse());
+
+        ShoppingListItem salt = response.items().stream()
+                .filter(i -> "Salt".equals(i.name()))
+                .findFirst()
+                .orElseThrow();
+        assertThat(salt.measures()).containsExactly("1 tsp", "2 tsp");
+        assertThat(salt.recipes()).containsExactly("Pasta", "Soup");
+    }
+
+    @Test
+    @DisplayName("save — nazwy przepisów są serializowane do JSON")
+    void save_recipeNamesAreSerializedCorrectly() {
+        SavedShoppingListResponse response = service.save("user-1", twoItemResponse());
+
+        ShoppingListItem garlic = response.items().stream()
+                .filter(i -> "Garlic".equals(i.name()))
+                .findFirst()
+                .orElseThrow();
+        assertThat(garlic.recipes()).containsExactly("Pasta");
+    }
+
+    @Test
+    @DisplayName("save — pusta lista elementów zapisuje pustą listę zakupów")
+    void save_emptyItems_savesEmptyList() {
+        ShoppingListResponse empty = new ShoppingListResponse(List.of());
+        SavedShoppingListResponse response = service.save("user-1", empty);
+        assertThat(response.items()).isEmpty();
+    }
+
+    // --- getHistory ---
+
+    @Test
+    @DisplayName("getHistory — zwraca zmapowane listy dla użytkownika")
+    void getHistory_returnsMappedListsForUser() {
+        UUID id = UUID.randomUUID();
+        when(shoppingListRepository.findByUserIdOrderByCreatedAtDesc("user-1"))
+                .thenReturn(List.of(savedList(id, "user-1")));
+
+        List<SavedShoppingListResponse> history = service.getHistory("user-1");
+
+        assertThat(history).hasSize(1);
+        assertThat(history.get(0).id()).isEqualTo(id);
+    }
+
+    @Test
+    @DisplayName("getHistory — JSON miary są deserializowane z powrotem do listy")
+    void getHistory_measuresAreDeserializedFromJson() {
+        when(shoppingListRepository.findByUserIdOrderByCreatedAtDesc("user-1"))
+                .thenReturn(List.of(savedList(UUID.randomUUID(), "user-1")));
+
+        List<SavedShoppingListResponse> history = service.getHistory("user-1");
+
+        ShoppingListItem salt = history.get(0).items().get(0);
+        assertThat(salt.name()).isEqualTo("Salt");
+        assertThat(salt.measures()).containsExactly("1 tsp", "2 tsp");
+        assertThat(salt.recipes()).containsExactly("Pasta", "Soup");
+    }
+
+    @Test
+    @DisplayName("getHistory — pusta historia zwraca pustą listę")
+    void getHistory_emptyHistory_returnsEmptyList() {
+        when(shoppingListRepository.findByUserIdOrderByCreatedAtDesc("user-1"))
+                .thenReturn(List.of());
+
+        List<SavedShoppingListResponse> history = service.getHistory("user-1");
+
+        assertThat(history).isEmpty();
+    }
+
+    @Test
+    @DisplayName("getHistory — null/pusty JSON measures deserializuje się do pustej listy")
+    void getHistory_nullMeasuresJson_returnsEmptyList() {
+        ShoppingList list = savedList(UUID.randomUUID(), "user-1");
+        list.getItems().get(0).setMeasures(null);
+        when(shoppingListRepository.findByUserIdOrderByCreatedAtDesc("user-1"))
+                .thenReturn(List.of(list));
+
+        List<SavedShoppingListResponse> history = service.getHistory("user-1");
+
+        assertThat(history.get(0).items().get(0).measures()).isEmpty();
+    }
+}

--- a/meal-planner-service/src/test/java/com/cookmate/mealplanner/service/WeeklyPlanPersistenceServiceTest.java
+++ b/meal-planner-service/src/test/java/com/cookmate/mealplanner/service/WeeklyPlanPersistenceServiceTest.java
@@ -4,6 +4,7 @@ import com.cookmate.mealplanner.dto.DayPlan;
 import com.cookmate.mealplanner.dto.MealItem;
 import com.cookmate.mealplanner.dto.SavedWeeklyPlanResponse;
 import com.cookmate.mealplanner.dto.WeeklyPlanResponse;
+import com.cookmate.mealplanner.exception.WeeklyPlanNotFoundException;
 import com.cookmate.mealplanner.model.WeeklyPlan;
 import com.cookmate.mealplanner.model.WeeklyPlanMeal;
 import com.cookmate.mealplanner.repository.WeeklyPlanRepository;
@@ -15,10 +16,13 @@ import org.mockito.MockitoAnnotations;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -179,5 +183,65 @@ class WeeklyPlanPersistenceServiceTest {
 
         assertThat(history.get(0).days()).extracting("day")
                 .containsExactly("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday");
+    }
+
+    // --- getMealIds ---
+
+    @Test
+    @DisplayName("getMealIds — zwraca listę mealId z planu należącego do użytkownika")
+    void getMealIds_returnsMealIdsForOwnedPlan() {
+        UUID planId = UUID.randomUUID();
+        when(weeklyPlanRepository.findByIdAndUserId(planId, "user-1"))
+                .thenReturn(Optional.of(savedPlan(planId, "user-1", 1)));
+
+        List<String> mealIds = service.getMealIds(planId, "user-1");
+
+        assertThat(mealIds).containsExactly("1");
+    }
+
+    @Test
+    @DisplayName("getMealIds — rzuca WeeklyPlanNotFoundException gdy plan nie istnieje")
+    void getMealIds_throwsWhenPlanNotFound() {
+        UUID planId = UUID.randomUUID();
+        when(weeklyPlanRepository.findByIdAndUserId(eq(planId), any()))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getMealIds(planId, "user-1"))
+                .isInstanceOf(WeeklyPlanNotFoundException.class)
+                .hasMessageContaining(planId.toString());
+    }
+
+    @Test
+    @DisplayName("getMealIds — rzuca WeeklyPlanNotFoundException gdy plan należy do innego użytkownika")
+    void getMealIds_throwsWhenPlanBelongsToDifferentUser() {
+        UUID planId = UUID.randomUUID();
+        when(weeklyPlanRepository.findByIdAndUserId(planId, "other-user"))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getMealIds(planId, "other-user"))
+                .isInstanceOf(WeeklyPlanNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("getMealIds — plan z wieloma posiłkami zwraca wszystkie mealId")
+    void getMealIds_multipleMeals_returnsAllIds() {
+        UUID planId = UUID.randomUUID();
+        WeeklyPlan plan = savedPlan(planId, "user-1", 2);
+
+        WeeklyPlanMeal second = new WeeklyPlanMeal();
+        second.setWeeklyPlan(plan);
+        second.setDayName("Tuesday");
+        second.setMealId("2");
+        second.setMealName("Soup");
+        second.setThumbnailUrl("https://thumb2.jpg");
+        plan.setMeals(new java.util.ArrayList<>(plan.getMeals()));
+        plan.getMeals().add(second);
+
+        when(weeklyPlanRepository.findByIdAndUserId(planId, "user-1"))
+                .thenReturn(Optional.of(plan));
+
+        List<String> mealIds = service.getMealIds(planId, "user-1");
+
+        assertThat(mealIds).containsExactly("1", "2");
     }
 }

--- a/meal-planner-service/src/test/java/com/cookmate/mealplanner/service/WeeklyPlanPersistenceServiceTest.java
+++ b/meal-planner-service/src/test/java/com/cookmate/mealplanner/service/WeeklyPlanPersistenceServiceTest.java
@@ -1,0 +1,183 @@
+package com.cookmate.mealplanner.service;
+
+import com.cookmate.mealplanner.dto.DayPlan;
+import com.cookmate.mealplanner.dto.MealItem;
+import com.cookmate.mealplanner.dto.SavedWeeklyPlanResponse;
+import com.cookmate.mealplanner.dto.WeeklyPlanResponse;
+import com.cookmate.mealplanner.model.WeeklyPlan;
+import com.cookmate.mealplanner.model.WeeklyPlanMeal;
+import com.cookmate.mealplanner.repository.WeeklyPlanRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@DisplayName("WeeklyPlanPersistenceService — unit tests")
+class WeeklyPlanPersistenceServiceTest {
+
+    @Mock
+    private WeeklyPlanRepository weeklyPlanRepository;
+
+    private WeeklyPlanPersistenceService service;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        service = new WeeklyPlanPersistenceService(weeklyPlanRepository);
+        when(weeklyPlanRepository.save(any(WeeklyPlan.class))).thenAnswer(invocation -> {
+            WeeklyPlan plan = invocation.getArgument(0);
+            plan.setId(UUID.fromString("00000000-0000-0000-0000-000000000001"));
+            return plan;
+        });
+    }
+
+    // --- helpers ---
+
+    private WeeklyPlanResponse twoMealPlan() {
+        List<MealItem> meals = List.of(
+                new MealItem("1", "Pasta", "https://thumb1.jpg"),
+                new MealItem("2", "Soup", "https://thumb2.jpg")
+        );
+        List<DayPlan> days = List.of(
+                new DayPlan("Monday", meals),
+                new DayPlan("Tuesday", meals),
+                new DayPlan("Wednesday", meals),
+                new DayPlan("Thursday", meals),
+                new DayPlan("Friday", meals),
+                new DayPlan("Saturday", meals),
+                new DayPlan("Sunday", meals)
+        );
+        return new WeeklyPlanResponse(days);
+    }
+
+    private WeeklyPlan savedPlan(UUID id, String userId, int mealsPerDay) {
+        WeeklyPlan plan = new WeeklyPlan();
+        plan.setId(id);
+        plan.setUserId(userId);
+        plan.setMealsPerDay(mealsPerDay);
+        plan.setCreatedAt(LocalDateTime.of(2026, 1, 10, 12, 0));
+
+        WeeklyPlanMeal meal = new WeeklyPlanMeal();
+        meal.setWeeklyPlan(plan);
+        meal.setDayName("Monday");
+        meal.setMealId("1");
+        meal.setMealName("Pasta");
+        meal.setThumbnailUrl("https://thumb1.jpg");
+        plan.setMeals(List.of(meal));
+        return plan;
+    }
+
+    // --- save ---
+
+    @Test
+    @DisplayName("save — wywołuje repository.save z odpowiednimi danymi")
+    void save_callsRepository() {
+        service.save("user-1", twoMealPlan());
+        verify(weeklyPlanRepository).save(any(WeeklyPlan.class));
+    }
+
+    @Test
+    @DisplayName("save — zwraca odpowiedź z wygenerowanym id")
+    void save_returnsResponseWithId() {
+        SavedWeeklyPlanResponse response = service.save("user-1", twoMealPlan());
+        assertThat(response.id()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("save — mealsPerDay jest obliczany z największej liczby posiłków w dniu")
+    void save_computesMealsPerDay() {
+        SavedWeeklyPlanResponse response = service.save("user-1", twoMealPlan());
+        assertThat(response.mealsPerDay()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("save — plan z pustymi dniami zapisuje mealsPerDay=0")
+    void save_emptyDays_mealsPerDayIsZero() {
+        WeeklyPlanResponse empty = new WeeklyPlanResponse(List.of(
+                new DayPlan("Monday", List.of())
+        ));
+        SavedWeeklyPlanResponse response = service.save("user-1", empty);
+        assertThat(response.mealsPerDay()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("save — zwrócona odpowiedź zawiera 7 dni w kolejności")
+    void save_responseContainsSevenDaysInOrder() {
+        SavedWeeklyPlanResponse response = service.save("user-1", twoMealPlan());
+        assertThat(response.days()).extracting("day")
+                .containsExactly("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday");
+    }
+
+    @Test
+    @DisplayName("save — posiłki są prawidłowo mapowane na dni")
+    void save_mealsAreMappedToCorrectDays() {
+        SavedWeeklyPlanResponse response = service.save("user-1", twoMealPlan());
+        assertThat(response.days().get(0).meals()).hasSize(2);
+        assertThat(response.days().get(0).meals().get(0).name()).isEqualTo("Pasta");
+    }
+
+    // --- getHistory ---
+
+    @Test
+    @DisplayName("getHistory — zwraca zmapowane plany dla użytkownika")
+    void getHistory_returnsMappedPlansForUser() {
+        UUID id = UUID.randomUUID();
+        when(weeklyPlanRepository.findByUserIdOrderByCreatedAtDesc("user-1"))
+                .thenReturn(List.of(savedPlan(id, "user-1", 1)));
+
+        List<SavedWeeklyPlanResponse> history = service.getHistory("user-1");
+
+        assertThat(history).hasSize(1);
+        assertThat(history.get(0).id()).isEqualTo(id);
+        assertThat(history.get(0).mealsPerDay()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("getHistory — pusta historia zwraca pustą listę")
+    void getHistory_emptyHistory_returnsEmptyList() {
+        when(weeklyPlanRepository.findByUserIdOrderByCreatedAtDesc("user-1"))
+                .thenReturn(List.of());
+
+        List<SavedWeeklyPlanResponse> history = service.getHistory("user-1");
+
+        assertThat(history).isEmpty();
+    }
+
+    @Test
+    @DisplayName("getHistory — posiłki są prawidłowo rekonstruowane z encji")
+    void getHistory_mealsAreReconstructedFromEntities() {
+        when(weeklyPlanRepository.findByUserIdOrderByCreatedAtDesc("user-1"))
+                .thenReturn(List.of(savedPlan(UUID.randomUUID(), "user-1", 1)));
+
+        List<SavedWeeklyPlanResponse> history = service.getHistory("user-1");
+
+        DayPlan monday = history.get(0).days().stream()
+                .filter(d -> "Monday".equals(d.day()))
+                .findFirst()
+                .orElseThrow();
+        assertThat(monday.meals()).hasSize(1);
+        assertThat(monday.meals().get(0).name()).isEqualTo("Pasta");
+    }
+
+    @Test
+    @DisplayName("getHistory — dni są zawsze zwracane w kolejności poniedziałek–niedziela")
+    void getHistory_daysAlwaysInWeekOrder() {
+        when(weeklyPlanRepository.findByUserIdOrderByCreatedAtDesc("user-1"))
+                .thenReturn(List.of(savedPlan(UUID.randomUUID(), "user-1", 1)));
+
+        List<SavedWeeklyPlanResponse> history = service.getHistory("user-1");
+
+        assertThat(history.get(0).days()).extracting("day")
+                .containsExactly("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday");
+    }
+}

--- a/meal-planner-service/src/test/resources/application-test.yml
+++ b/meal-planner-service/src/test/resources/application-test.yml
@@ -7,6 +7,21 @@ spring:
     loadbalancer:
       ribbon:
         enabled: false
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+  sql:
+    init:
+      mode: never
   security:
     oauth2:
       resourceserver:


### PR DESCRIPTION
## Opis

Implementacja persystencji w `meal-planner-service` — zapisywanie wygenerowanych planów tygodniowych i list zakupów w bazie danych, powiązanych z konkretnym użytkownikiem (na podstawie JWT). Dodano też pełną integrację frontendową umożliwiającą generowanie, zapisywanie, przeglądanie historii i usuwanie planów oraz list zakupów.

## Backend

- Nowa baza danych PostgreSQL z osobnym schematem `meal_planner`
- Entity i repozytoria: `WeeklyPlan`, `WeeklyPlanMeal`, `ShoppingList`, `ShoppingListItemEntity`
- Endpointy zapisu i odczytu historii:
  - `POST /weekly-plan/save`, `GET /weekly-plan/history`
  - `POST /shopping-list/save`, `GET /shopping-list/history`
  - `DELETE /weekly-plan/{id}` (z weryfikacją właściciela przez userId z JWT)
- Nowy endpoint `POST /shopping-list/from-plan/{weeklyPlanId}` — generowanie listy zakupów na podstawie zapisanego planu tygodniowego
- ID użytkownika wyciągane z tokenu JWT (`jwt.getSubject()`) — bez dodatkowych wywołań do innych serwisów
- Przeprojektowanie logiki generowania planu tygodniowego — wprowadzenie "slotów" posiłków (Breakfast/Main/Starter/Side/Dessert) zamiast czysto losowych kategorii, w zależności od `mealsPerDay` (1-5)
- 71+ testów jednostkowych i integracyjnych pokrywających nową logikę

## Frontend

- Nowy widok **Meal Planner** dostępny z Header
- Generowanie planu tygodniowego (wybór liczby posiłków dziennie) i wyświetlanie wyniku w kartach dla każdego dnia
- Zapisywanie wygenerowanego planu
- Wspólny, jeden widok aktualnie wygenerowanej/wybranej listy zakupów
- Historia zapisanych planów i list zakupów (sekcje rozwijane), z możliwością usuwania planów
- Przycisk "Cook" przy każdym posiłku w planie — prowadzi do istniejącego flow guided cooking
- Obsługa stanu niezalogowanego — wymusza modal logowania zamiast wysyłania żądań bez tokenu
- Ulepszona obsługa błędów — czytelne komunikaty dla błędów sieciowych i znanych kodów backendu

## Infrastruktura

- Dodanie trasy `meal-planner-service` w gateway (`config-repo/gateway-service.yml`) — wcześniej requesty `/api/planner/**` były przechwytywane przez catch-all trasę `main-service`

Closes #218 